### PR TITLE
Mapper implentation based on union of policies associated with a user and its groups.

### DIFF
--- a/emr-user-role-mapper-application/pom.xml
+++ b/emr-user-role-mapper-application/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <aws-java-sdk.version>1.11.483</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.896</aws-java-sdk.version>
         <guava.version>[24.1.1,)</guava.version>
         <gson.version>2.8.5</gson.version>
         <java.version>1.8</java.version>
@@ -99,6 +99,11 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
@@ -4,6 +4,8 @@
 package com.amazon.aws.emr;
 
 import com.amazon.aws.emr.common.Constants;
+import com.google.common.collect.Maps;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.hk2.api.Immediate;
 
@@ -84,5 +86,9 @@ public class ApplicationConfiguration {
      */
     public void setProperty(String propertyName, String value) {
         properties.put(propertyName, value);
+    }
+
+    public Map<String, String> asMap() {
+        return Maps.fromProperties(properties);
     }
 }

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -5,6 +5,7 @@ package com.amazon.aws.emr.common;
 
 import com.amazon.aws.emr.mapping.DefaultUserRoleMapperImpl;
 
+import com.amazon.aws.emr.mapping.ManagedPolicyBasedUserRoleMapperImpl;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
@@ -26,6 +27,10 @@ final public class Constants {
      */
     public static final String ROLE_MAPPING_S3_BUCKET = "rolemapper.s3.bucket";
     /**
+     * AWS Role to be used for role mapping. This is used in {@link ManagedPolicyBasedUserRoleMapperImpl}
+     */
+    public static final String ROLE_MAPPING_ROLE_ARN = "rolemapper.role.arn";
+    /**
      * S3 Bucket for the role mapping file.
      */
     public static final String ROLE_MAPPING_MAX_THREADS = "rolemapper.max.threads";
@@ -37,6 +42,7 @@ final public class Constants {
      * Key for the role mapping file.
      */
     public static final String ROLE_MAPPING_S3_KEY = "rolemapper.s3.key";
+
     /**
      * Duration in mins to check for new mapping.
      */
@@ -50,6 +56,13 @@ final public class Constants {
      * Default S3 Mapper Impl for JSON format.
      */
     public static final String ROLE_MAPPING_DEFAULT_CLASSNAME = DefaultUserRoleMapperImpl.class.getName();
+
+    /**
+     * Default S3 Mapper Impl for JSON format.
+     */
+    public static final String ROLE_MAPPING_MANAGED_POLICY_CLASSNAME = ManagedPolicyBasedUserRoleMapperImpl
+        .class.getName();
+
     /**
      * Constants related with joda DateTime and JSON
      */

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/ManagedPolicyBasedUserRoleMapperImpl.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/ManagedPolicyBasedUserRoleMapperImpl.java
@@ -1,0 +1,133 @@
+package com.amazon.aws.emr.mapping;
+
+import com.amazon.aws.emr.common.Constants;
+import com.amazon.aws.emr.common.system.PrincipalResolver;
+import com.amazon.aws.emr.model.PrincipalPolicyMapping;
+import com.amazon.aws.emr.model.PrincipalPolicyMappings;
+import com.amazon.aws.emr.rolemapper.UserRoleMapperProvider;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.PolicyDescriptorType;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Mapping impl based on union of policies after principal resolution.
+ */
+@Slf4j
+@NoArgsConstructor
+public class ManagedPolicyBasedUserRoleMapperImpl extends S3BasedUserMappingImplBase
+    implements UserRoleMapperProvider {
+
+  private PrincipalResolver principalResolver;
+  private String roleArn;
+
+  private final Map<String, List<PolicyDescriptorType>> principalRoleMapping = new HashMap<>();
+
+  private static final Gson GSON = new GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+      .setPrettyPrinting()
+      .create();
+
+  public ManagedPolicyBasedUserRoleMapperImpl(String bucketName, String key,
+      PrincipalResolver principalResolver) {
+    this.bucketName = Objects.requireNonNull(bucketName);
+
+    // TODO: We may relax this to allow null value. In case of null value, parse all keys under above bucket
+    this.key = Objects.requireNonNull(key);
+    this.etag = null;
+    this.principalResolver = Objects.requireNonNull(principalResolver);
+  }
+
+  @Override
+  public void init(Map<String, String> configMap) {
+    roleArn = Objects.requireNonNull(configMap.get(Constants.ROLE_MAPPING_ROLE_ARN));
+  }
+
+  @Override
+  public Optional<AssumeRoleRequest> getMapping(String username) {
+    List<String> principals = new ArrayList<>();
+    List<PolicyDescriptorType> policyDescriptorTypes = new ArrayList<>();
+
+    principals.add(username);
+    Optional<List<String>> groups = principalResolver.getGroups(username);
+    if (groups.isPresent()) {
+      principals.addAll(groups.get());
+    }
+
+    principals.stream()
+        .map(principal -> principalRoleMapping.getOrDefault(principal, Collections.emptyList()))
+        .filter(policies -> !policies.isEmpty())
+        .flatMap(List::stream)
+        .distinct()
+        .forEach(policyDescriptorTypes::add);
+    if (policyDescriptorTypes.isEmpty()) {
+      return Optional.empty();
+    }
+
+    AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest()
+        .withRoleArn(roleArn)
+        .withRoleSessionName(username)
+        .withPolicyArns(policyDescriptorTypes);
+    return Optional.of(assumeRoleRequest);
+  }
+
+  @Override
+  void processFile(String jsonString) {
+    log.info("Received the following JSON {}", jsonString);
+    PrincipalPolicyMappings principalPolicyMappings = GSON
+        .fromJson(jsonString, PrincipalPolicyMappings.class);
+    // Clear the old mapping now since we found a new valid mapping!
+    principalRoleMapping.clear();
+
+    for (PrincipalPolicyMapping principalPolicyMapping : principalPolicyMappings
+        .getPrincipalPolicyMappings()) {
+      if (!isValidMapping(principalPolicyMapping)) {
+        log.info("Invalid record!");
+        continue;
+      }
+
+      String principal =
+          principalPolicyMapping.getUsername() != null ? principalPolicyMapping.getUsername() :
+              principalPolicyMapping.getGroupname();
+
+      List<PolicyDescriptorType> policyDescriptorTypes = new ArrayList<>();
+      principalPolicyMapping.getPolicyArns().stream()
+          .map(p -> new PolicyDescriptorType().withArn(p))
+          .forEach(policyDescriptorTypes::add);
+
+      principalRoleMapping.put(principal, policyDescriptorTypes);
+
+      log.info("Mapped {} to {}", principal, principalPolicyMapping.getPolicyArns());
+    }
+  }
+
+  boolean isValidMapping(PrincipalPolicyMapping principalPolicyMapping) {
+    if (principalPolicyMapping == null) {
+      log.info("Invalid record!");
+      return false;
+    }
+    String principal =
+        principalPolicyMapping.getUsername() != null ? principalPolicyMapping.getUsername() :
+            principalPolicyMapping.getGroupname();
+    if (principal == null) {
+      log.info("Invalid record containing no username or groupname {}", principalPolicyMapping);
+      return false;
+    }
+
+    if (principalPolicyMapping.getPolicyArns() == null || principalPolicyMapping.getPolicyArns().isEmpty()) {
+      log.info("Invalid record containing no policy {}", principalPolicyMapping);
+      return false;
+    }
+    return true;
+  }
+}

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/S3BasedUserMappingImplBase.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/S3BasedUserMappingImplBase.java
@@ -1,0 +1,81 @@
+package com.amazon.aws.emr.mapping;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Common functionality to fetch and retrieve mappings stored in S3.
+ */
+@Slf4j
+public abstract class S3BasedUserMappingImplBase {
+
+  protected String bucketName;
+  protected String key;
+  protected String etag;
+  static final AmazonS3 s3Client = AmazonS3ClientBuilder.standard().build();
+
+  public void refresh() {
+    log.debug("Checking if need to load mapping again from S3 from {}/{}", bucketName, key);
+    ObjectMetadata objectMetadata = s3Client.getObjectMetadata(bucketName, key);
+    if (objectMetadata.getETag().equals(etag)) {
+      log.debug("Nothing to do as current etag {} matches the last one.", objectMetadata.getETag());
+    } else {
+      log.info("Seems we have new mapping - reload it.");
+      readMapping();
+      log.info("Done with the reload.");
+    }
+  }
+
+  /**
+   * Process the contents of S3 mapping file.
+   *
+   * @param json the contents of the S3 mapping.
+   */
+  abstract void processFile(String json);
+
+  private void readMapping() {
+    log.info("Load the mapping from S3 from {}/{}", bucketName, key);
+    try (S3Object s3object = s3Client.getObject(new GetObjectRequest(
+        bucketName, key))){
+      S3ObjectInputStream s3InputStream = s3object.getObjectContent();
+      String jsonString = null;
+      try {
+        jsonString = getS3FileAsString(s3InputStream);
+      } catch (IOException e) {
+        throw new RuntimeException("Could not fetch the mapping file from S3.", e);
+      }
+      // Update the ETag
+      etag = s3object.getObjectMetadata().getETag();
+      processFile(jsonString);
+    } catch (AmazonClientException ace) {
+      log.error("AWS exception {}", ace.getMessage(), ace);
+    } catch (IOException e) {
+      log.error("Could not load mapping from S3", e);
+    }
+  }
+
+  private static String getS3FileAsString(InputStream is) throws IOException {
+    if (is == null)
+      return null;
+    StringBuilder sb = new StringBuilder();
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(is, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        sb.append(line);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMapping.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMapping.java
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.aws.emr.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PrincipalPolicyMapping {
+
+    @SerializedName("username")
+    private String username;
+
+    @SerializedName("groupname")
+    private String groupname;
+
+    @SerializedName("policies")
+    private java.util.List<String> policyArns;
+}

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMappings.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMappings.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.aws.emr.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class PrincipalPolicyMappings {
+    @SerializedName("PrincipalPolicyMappings")
+    PrincipalPolicyMapping[] principalPolicyMappings;
+}

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/credentials/STSCredentialsProviderTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/credentials/STSCredentialsProviderTest.java
@@ -3,11 +3,20 @@
 
 package com.amazon.aws.emr.credentials;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.Is.is;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.util.EC2MetadataUtils;
+import java.util.Date;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,137 +27,130 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.time.Duration;
-import java.util.Date;
-import java.util.Optional;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.core.Is.is;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({STSCredentialsProvider.class})
 @PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
 public class STSCredentialsProviderTest {
 
-    private static final long ONE_HR_MS = 60 * 60 * 1000;
+  private static final long ONE_HR_MS = 60 * 60 * 1000;
 
-    private static final long TWO_MIN_MS = 2 * 60 * 1000;
+  private static final long TWO_MIN_MS = 2 * 60 * 1000;
 
-    @Mock
-    AWSSecurityTokenService stsClient;
+  @Mock
+  AWSSecurityTokenService stsClient;
 
-    AssumeRoleRequest assumeRoleRequest;
+  AssumeRoleRequest assumeRoleRequest;
 
-    @Before
-    public void setup() {
-        mockStatic(STSCredentialsProvider.class);
-        Mockito.when(STSCredentialsProvider.getStsClient())
-                .thenReturn(stsClient);
-        Mockito.when(STSCredentialsProvider.createInterceptorDateTimeFormat()).thenCallRealMethod();
-        assumeRoleRequest = createTestAssumeRoleRequest();
-    }
+  @Before
+  public void setup() {
+    mockStatic(STSCredentialsProvider.class);
+    Mockito.when(STSCredentialsProvider.getStsClient())
+        .thenReturn(stsClient);
+    Mockito.when(STSCredentialsProvider.createInterceptorDateTimeFormat()).thenCallRealMethod();
+    assumeRoleRequest = createTestAssumeRoleRequest();
+  }
 
-    @Test
-    public void get_credentials() {
-        Credentials longLivedCredentials = createTestCredentials(ONE_HR_MS);
-        Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
-                new AssumeRoleResult()
-                        .withCredentials(longLivedCredentials));
-        STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
-        Optional<EC2MetadataUtils.IAMSecurityCredential> optionalIAMSecurityCredentials = stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
-        assertThat(optionalIAMSecurityCredentials.isPresent(), is(true));
-        EC2MetadataUtils.IAMSecurityCredential iamSecurityCredential = optionalIAMSecurityCredentials.get();
-        assertThat(iamSecurityCredential.accessKeyId, is("test-access"));
-        assertThat(iamSecurityCredential.secretAccessKey, is("test-secret"));
-        assertThat(iamSecurityCredential.code, is("Success"));
-        assertThat(iamSecurityCredential.code, is("Success"));
-        assertThat(iamSecurityCredential.expiration, is(
-                STSCredentialsProvider.createInterceptorDateTimeFormat().format(longLivedCredentials.getExpiration())));
-    }
+  @Test
+  public void get_credentials() {
+    Credentials longLivedCredentials = createTestCredentials(ONE_HR_MS);
+    Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
+        new AssumeRoleResult()
+            .withCredentials(longLivedCredentials));
+    STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
+    Optional<EC2MetadataUtils.IAMSecurityCredential> optionalIAMSecurityCredentials = stsCredentialsProvider
+        .getUserCredentials(assumeRoleRequest);
+    assertThat(optionalIAMSecurityCredentials.isPresent(), is(true));
+    EC2MetadataUtils.IAMSecurityCredential iamSecurityCredential = optionalIAMSecurityCredentials
+        .get();
+    assertThat(iamSecurityCredential.accessKeyId, is("test-access"));
+    assertThat(iamSecurityCredential.secretAccessKey, is("test-secret"));
+    assertThat(iamSecurityCredential.code, is("Success"));
+    assertThat(iamSecurityCredential.code, is("Success"));
+    assertThat(iamSecurityCredential.expiration, is(
+        STSCredentialsProvider.createInterceptorDateTimeFormat()
+            .format(longLivedCredentials.getExpiration())));
+  }
 
-    @Test
-    public void get_cached_credentials() {
-        Credentials longLivedCredentials = createTestCredentials(ONE_HR_MS);
-        Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
-                new AssumeRoleResult()
-                        .withCredentials(longLivedCredentials));
+  @Test
+  public void get_cached_credentials() {
+    Credentials longLivedCredentials = createTestCredentials(ONE_HR_MS);
+    Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
+        new AssumeRoleResult()
+            .withCredentials(longLivedCredentials));
 
-        STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+    STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
 
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(1));
-        STSCredentialsProvider.getStsClient();
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(1));
+    STSCredentialsProvider.getStsClient();
 
-        // Make the second call
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
-        // The invocations with STS client don't go up
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(1));
-        STSCredentialsProvider.getStsClient();
-    }
+    // Make the second call
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+    // The invocations with STS client don't go up
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(1));
+    STSCredentialsProvider.getStsClient();
+  }
 
-    @Test
-    public void expired_credentials() {
-        Credentials shortLivedTestCredentials = createTestCredentials(-1);
-        Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
-                new AssumeRoleResult()
-                        .withCredentials(shortLivedTestCredentials));
-        STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+  @Test
+  public void expired_credentials() {
+    Credentials shortLivedTestCredentials = createTestCredentials(-1);
+    Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
+        new AssumeRoleResult()
+            .withCredentials(shortLivedTestCredentials));
+    STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
 
-        /*
-         * Why 2?
-         * First call gets the credentials using sts as the cache is empty.
-         * Second call is made to STS as the retrieved credentials are expired.
-         */
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(2));
-        STSCredentialsProvider.getStsClient();
+    /*
+     * Why 2?
+     * First call gets the credentials using sts as the cache is empty.
+     * Second call is made to STS as the retrieved credentials are expired.
+     */
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(2));
+    STSCredentialsProvider.getStsClient();
 
-        // Make second call, should invoke STS client again
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(3));
-        STSCredentialsProvider.getStsClient();
-    }
+    // Make second call, should invoke STS client again
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(3));
+    STSCredentialsProvider.getStsClient();
+  }
 
-    @Test
-    public void about_to_expire_credentials() {
-        Credentials shortLivedTestCredentials = createTestCredentials(TWO_MIN_MS);
-        Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
-                new AssumeRoleResult()
-                        .withCredentials(shortLivedTestCredentials));
-        STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(2));
-        STSCredentialsProvider.getStsClient();
+  @Test
+  public void about_to_expire_credentials() {
+    Credentials shortLivedTestCredentials = createTestCredentials(TWO_MIN_MS);
+    Mockito.when(stsClient.assumeRole(assumeRoleRequest)).thenReturn(
+        new AssumeRoleResult()
+            .withCredentials(shortLivedTestCredentials));
+    STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(2));
+    STSCredentialsProvider.getStsClient();
 
-        // Make second call, should invoke STS client again
-        stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
-        PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(3));
-        STSCredentialsProvider.getStsClient();
-    }
+    // Make second call, should invoke STS client again
+    stsCredentialsProvider.getUserCredentials(assumeRoleRequest);
+    PowerMockito.verifyStatic(STSCredentialsProvider.class, Mockito.times(3));
+    STSCredentialsProvider.getStsClient();
+  }
 
-    @Test
-    public void random_refresh_time() {
-        STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
-        assertThat(stsCredentialsProvider.getRandomTimeInRange(), allOf(greaterThan(STSCredentialsProvider.MIN_REMAINING_TIME_TO_REFRESH_CREDENTIALS.toMillis()),
-                lessThan(STSCredentialsProvider.MIN_REMAINING_TIME_TO_REFRESH_CREDENTIALS.toMillis() +
-                        STSCredentialsProvider.MAX_RANDOM_TIME_TO_REFRESH_CREDENTIALS.toMillis())));
-    }
+  @Test
+  public void random_refresh_time() {
+    STSCredentialsProvider stsCredentialsProvider = new STSCredentialsProvider();
+    assertThat(stsCredentialsProvider.getRandomTimeInRange(), allOf(
+        greaterThan(STSCredentialsProvider.MIN_REMAINING_TIME_TO_REFRESH_CREDENTIALS.toMillis()),
+        lessThan(STSCredentialsProvider.MIN_REMAINING_TIME_TO_REFRESH_CREDENTIALS.toMillis() +
+            STSCredentialsProvider.MAX_RANDOM_TIME_TO_REFRESH_CREDENTIALS.toMillis())));
+  }
 
-    private Credentials createTestCredentials(long xp) {
-        return new Credentials().withAccessKeyId("test-access")
-                .withSecretAccessKey("test-secret")
-                .withSessionToken("test-session")
-                .withExpiration(new Date(System.currentTimeMillis() + xp));
-    }
+  private Credentials createTestCredentials(long xp) {
+    return new Credentials().withAccessKeyId("test-access")
+        .withSecretAccessKey("test-secret")
+        .withSessionToken("test-session")
+        .withExpiration(new Date(System.currentTimeMillis() + xp));
+  }
 
 
-    private AssumeRoleRequest createTestAssumeRoleRequest() {
-        return new AssumeRoleRequest()
-                .withRoleArn("test-arn")
-                .withRoleSessionName("test-session");
-    }
+  private AssumeRoleRequest createTestAssumeRoleRequest() {
+    return new AssumeRoleRequest()
+        .withRoleArn("test-arn")
+        .withRoleSessionName("test-session");
+  }
 }

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/ManagedPolicyBasedUserRoleMapperImplTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/ManagedPolicyBasedUserRoleMapperImplTest.java
@@ -1,0 +1,128 @@
+package com.amazon.aws.emr.mapping;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.core.Is.is;
+
+import com.amazon.aws.emr.common.Constants;
+import com.amazon.aws.emr.common.system.PrincipalResolver;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ManagedPolicyBasedUserRoleMapperImplTest {
+
+  ManagedPolicyBasedUserRoleMapperImpl managedPolicyBasedUserRoleMapper;
+
+  @Mock
+  PrincipalResolver principalResolver;
+
+  private static final String TEST_BUCKET = "testBucket";
+  private static final String TEST_KEY = "testKey";
+  private static final String MAPPING_ROLE_ARN = "arn:aws:s3:::MappingRole";
+  private static final String mappingJson =  "{\n" +
+      "  \"PrincipalPolicyMappings\": [\n" +
+      "    {\n" +
+      "      \"username\": \"u1\",\n" +
+      "      \"policies\": [\n" +
+      "        \"arn:aws:s3:::UserPolicy\"\n" +
+      "      ]\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"username\": \"g1\",\n" +
+      "      \"policies\": [\n" +
+      "        \"arn:aws:s3:::Group1-P1\",\n" +
+      "        \"arn:aws:s3:::Group1-P2\",\n" +
+      "        \"arn:aws:s3:::Group-Common\"\n" +
+      "      ]\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"groupname\": \"g2\",\n" +
+      "      \"policies\": [\n" +
+      "        \"arn:aws:s3:::Group2-P1\"\n," +
+      "        \"arn:aws:s3:::Group-Common\"\n" +
+      "      ]\n" +
+      "    }\n" +
+      "  ]\n" +
+      "}";
+
+  @Before
+  public void setUp() {
+    managedPolicyBasedUserRoleMapper =
+        new ManagedPolicyBasedUserRoleMapperImpl(TEST_BUCKET, TEST_KEY, principalResolver);
+    managedPolicyBasedUserRoleMapper.init(Collections.singletonMap(Constants.ROLE_MAPPING_ROLE_ARN,
+        MAPPING_ROLE_ARN));
+    managedPolicyBasedUserRoleMapper.processFile(mappingJson);
+  }
+
+  @Test
+  public void user_with_one_group_assumeRoleRequest() {
+    when(principalResolver.getGroups(eq("u1"))).thenReturn(Optional.of(Collections.singletonList("g1")));
+    Optional<AssumeRoleRequest> optionalAssumeRoleRequest = managedPolicyBasedUserRoleMapper.getMapping("u1");
+    assertThat(optionalAssumeRoleRequest.isPresent(), is(true));
+    AssumeRoleRequest assumeRoleRequest = optionalAssumeRoleRequest.get();
+    assertThat(assumeRoleRequest.getRoleArn(), is(MAPPING_ROLE_ARN));
+    assertThat(assumeRoleRequest.getPolicyArns(), hasSize(4));
+    assertThat(assumeRoleRequest.getPolicyArns().get(0).getArn(), is("arn:aws:s3:::UserPolicy"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(1).getArn(), is("arn:aws:s3:::Group1-P1"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(2).getArn(), is("arn:aws:s3:::Group1-P2"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(3).getArn(), is("arn:aws:s3:::Group-Common"));
+  }
+
+  @Test
+  public void user_with_two_groups_assumeRoleRequest() {
+    when(principalResolver.getGroups(eq("u1"))).thenReturn(Optional.of(Arrays.asList("g1", "g2")));
+    Optional<AssumeRoleRequest> optionalAssumeRoleRequest = managedPolicyBasedUserRoleMapper.getMapping("u1");
+    assertThat(optionalAssumeRoleRequest.isPresent(), is(true));
+    AssumeRoleRequest assumeRoleRequest = optionalAssumeRoleRequest.get();
+    assertThat(assumeRoleRequest.getRoleArn(), is(MAPPING_ROLE_ARN));
+    assertThat(assumeRoleRequest.getPolicyArns(), hasSize(5));
+    assertThat(assumeRoleRequest.getPolicyArns().get(0).getArn(), is("arn:aws:s3:::UserPolicy"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(1).getArn(), is("arn:aws:s3:::Group1-P1"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(2).getArn(), is("arn:aws:s3:::Group1-P2"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(3).getArn(), is("arn:aws:s3:::Group-Common"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(4).getArn(), is("arn:aws:s3:::Group2-P1"));
+  }
+
+  @Test
+  public void user_with_no_groups_assumeRoleRequest() {
+    when(principalResolver.getGroups(eq("u1"))).thenReturn(Optional.of(Collections.emptyList()));
+    Optional<AssumeRoleRequest> optionalAssumeRoleRequest = managedPolicyBasedUserRoleMapper.getMapping("u1");
+    assertThat(optionalAssumeRoleRequest.isPresent(), is(true));
+    AssumeRoleRequest assumeRoleRequest = optionalAssumeRoleRequest.get();
+    assertThat(assumeRoleRequest.getRoleArn(), is(MAPPING_ROLE_ARN));
+    assertThat(assumeRoleRequest.getPolicyArns(), hasSize(1));
+    assertThat(assumeRoleRequest.getPolicyArns().get(0).getArn(), is("arn:aws:s3:::UserPolicy"));
+  }
+
+  @Test
+  public void user_with_no_mapping_assumeRoleRequest() {
+    when(principalResolver.getGroups(eq("u2"))).thenReturn(Optional.of(Collections.emptyList()));
+    Optional<AssumeRoleRequest> optionalAssumeRoleRequest = managedPolicyBasedUserRoleMapper
+        .getMapping("u2");
+    assertThat(optionalAssumeRoleRequest.isPresent(), is(false));
+  }
+
+  @Test
+  public void user_with_no_username_mapping_assumeRoleRequest() {
+    when(principalResolver.getGroups(eq("u3"))).thenReturn(Optional.of(Collections.singletonList("g1")));
+    Optional<AssumeRoleRequest> optionalAssumeRoleRequest = managedPolicyBasedUserRoleMapper
+        .getMapping("u3");
+    assertThat(optionalAssumeRoleRequest.isPresent(), is(true));
+    AssumeRoleRequest assumeRoleRequest = optionalAssumeRoleRequest.get();
+    assertThat(assumeRoleRequest.getRoleArn(), is(MAPPING_ROLE_ARN));
+    assertThat(assumeRoleRequest.getPolicyArns(), hasSize(3));
+    assertThat(assumeRoleRequest.getPolicyArns().get(0).getArn(), is("arn:aws:s3:::Group1-P1"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(1).getArn(), is("arn:aws:s3:::Group1-P2"));
+    assertThat(assumeRoleRequest.getPolicyArns().get(2).getArn(), is("arn:aws:s3:::Group-Common"));
+  }
+}

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/MappingInvokerTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/MappingInvokerTest.java
@@ -1,0 +1,27 @@
+package com.amazon.aws.emr.mapping;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.amazon.aws.emr.common.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+public class MappingInvokerTest {
+
+  MappingInvoker mappingInvoker = new MappingInvoker();
+
+  @Test
+  public void is_s3_based_impl() {
+    assertThat(mappingInvoker.isS3BasedProviderImpl("my.class"), is(false));
+    assertThat(mappingInvoker.isS3BasedProviderImpl(Constants.ROLE_MAPPING_DEFAULT_CLASSNAME),
+        is(true));
+    assertThat(
+        mappingInvoker.isS3BasedProviderImpl(Constants.ROLE_MAPPING_MANAGED_POLICY_CLASSNAME),
+        is(true));
+  }
+}

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/TestUserRoleMapperImpl.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/TestUserRoleMapperImpl.java
@@ -27,7 +27,7 @@ public class TestUserRoleMapperImpl implements UserRoleMapperProvider {
     private PrincipalResolver principalResolver;
 
     @Override
-    public void init() {
+    public void init(Map<String, String> configMap) {
         AssumeRoleRequest assumeRoleRequestU1 = new AssumeRoleRequest()
                 .withRoleArn("arn:aws:iam::123456789:role/u1")
                 .withRoleSessionName("u1");

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/model/PrincipalPolicyMappingsTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/model/PrincipalPolicyMappingsTest.java
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.aws.emr.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.collect.Lists;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class PrincipalPolicyMappingsTest {
+    final Gson GSON = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+            .setPrettyPrinting()
+            .create();
+
+    @Test
+    public void serialization() {
+        PrincipalPolicyMappings mappings = new PrincipalPolicyMappings();
+
+        PrincipalPolicyMapping e1 = new PrincipalPolicyMapping();
+        e1.setUsername("u1");
+        List<String> policies = new ArrayList<>();
+        policies.add("arn:aws:s3:::NewHireOrientation1");
+        policies.add("arn:aws:s3:::NewHireOrientation2");
+        policies.add("arn:aws:s3:::NewHireOrientation3");
+        policies.add("arn:aws:s3:::NewHireOrientation4");
+        e1.setPolicyArns(policies);
+
+        PrincipalPolicyMapping e2 = new PrincipalPolicyMapping();
+        e2.setGroupname("g1");
+        List<String> gpPolicies = new ArrayList<>();
+        gpPolicies.add("arn:aws:s3:::MyBucket");
+        e2.setPolicyArns(gpPolicies);
+
+        mappings.principalPolicyMappings = new PrincipalPolicyMapping[2];
+        mappings.principalPolicyMappings[0] = e1;
+        mappings.principalPolicyMappings[1] = e2;
+
+        String expected = "{\n" +
+                "  \"PrincipalPolicyMappings\": [\n" +
+                "    {\n" +
+                "      \"username\": \"u1\",\n" +
+                "      \"policies\": [\n" +
+                "        \"arn:aws:s3:::NewHireOrientation1\",\n" +
+                "        \"arn:aws:s3:::NewHireOrientation2\",\n" +
+                "        \"arn:aws:s3:::NewHireOrientation3\",\n" +
+                "        \"arn:aws:s3:::NewHireOrientation4\"\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"groupname\": \"g1\",\n" +
+                "      \"policies\": [\n" +
+                "        \"arn:aws:s3:::MyBucket\"\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        assertThat(expected, is(GSON.toJson(mappings)));
+    }
+
+    @Test
+    public void deserialization() {
+        String json = "{\n" +
+            "  \"PrincipalPolicyMappings\": [\n" +
+            "    {\n" +
+            "      \"username\": \"u1\",\n" +
+            "      \"policies\": [\n" +
+            "        \"arn:aws:s3:::NewHireOrientation1\",\n" +
+            "        \"arn:aws:s3:::NewHireOrientation2\",\n" +
+            "        \"arn:aws:s3:::NewHireOrientation3\",\n" +
+            "        \"arn:aws:s3:::NewHireOrientation4\"\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"groupname\": \"g1\",\n" +
+            "      \"policies\": [\n" +
+            "        \"arn:aws:s3:::MyBucket\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+        PrincipalPolicyMappings principalPolicyMappings = GSON
+            .fromJson(json, PrincipalPolicyMappings.class);
+        assertThat(principalPolicyMappings.getPrincipalPolicyMappings().length, is(2));
+
+        PrincipalPolicyMapping mapping1 = principalPolicyMappings.getPrincipalPolicyMappings()[0];
+        assertThat(mapping1, is(PrincipalPolicyMapping.builder()
+            .username("u1")
+            .policyArns(Arrays.asList("arn:aws:s3:::NewHireOrientation1",
+                "arn:aws:s3:::NewHireOrientation2", "arn:aws:s3:::NewHireOrientation3",
+                "arn:aws:s3:::NewHireOrientation4"))
+            .build()));
+
+        PrincipalPolicyMapping mapping2 = principalPolicyMappings.getPrincipalPolicyMappings()[1];
+        assertThat(mapping2, is(PrincipalPolicyMapping.builder()
+            .groupname("g1")
+            .policyArns(Arrays.asList("arn:aws:s3:::MyBucket"))
+            .build()));
+    }
+}

--- a/emr-user-role-mapper-interface/src/main/java/com/amazon/aws/emr/rolemapper/UserRoleMapperProvider.java
+++ b/emr-user-role-mapper-interface/src/main/java/com/amazon/aws/emr/rolemapper/UserRoleMapperProvider.java
@@ -5,6 +5,7 @@ package com.amazon.aws.emr.rolemapper;
 
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 
+import java.util.Map;
 import java.util.Optional;
 
 public interface UserRoleMapperProvider {
@@ -12,7 +13,7 @@ public interface UserRoleMapperProvider {
     /**
      * Used to initialize the mapper. This is invoked once at Application start.
      */
-    void init();
+    void init(Map<String, String> configMap);
 
     /**
      * Fetch the {@link AssumeRoleRequest} to assume for a given user.


### PR DESCRIPTION
A common Role is used to scope down the credentials.
The common functionality to fetch and refresh policies from S3 has been moved
to a common class.


*Issue #, if available:*
https://github.com/awslabs/amazon-emr-user-role-mapper/issues/8

*Description of changes:*
* Mapper based on union of policies. The calling users mapping for username and groups are determined. These are then used to return back credentials to the user.
    * Each principal (user/group) in the mapping JSON maps to a list of managed policies (ARN)
    * A Role ARN is provided in the Application Config that is “assumed”, and scoped down credentials from the policies are returned.
    * If no user/group mapping is found then empty credentials are returned
    * STS requires that the number of managed policies should not exceed 10
    * The role session name is the same as the calling username
    * The following show the changes to the application config, and the format of the new mapping file
```    
      rolemapper.class.name=com.amazon.aws.emr.mapping.ManagedPolicyBasedUserRoleMapperImpl
      rolemapper.role.arn=arn:aws:iam::<ACC_ID>:role/<BASE_ROLE>
```
```
     {
        "PrincipalPolicyMappings": [
          {
            "username": "test-user1",
            "policies": ["arn:aws:iam::176430881729:policy/test-sk-p1"]
          },
          {
            "username": "test-gp1",
            "policies": ["arn:aws:iam::176430881729:policy/test-sk-p2"]
          }
        ]
        }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
