### PR TITLE
1. Use command strategy to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,45 @@ sudo -u mapped-user aws s3 ls s3://my-custom-mapper/install
 2020-09-11 19:07:41        254 user-role-mapper.properties
 ```
 
+### Integration tests
+- Set the AWS credentials to be available to the environment before running the tests.
+- Like here is one way to do it
+
+```
+export AWS_ACCESS_KEY_ID="ASIASSFAZTPATNBHFC56"
+export AWS_SECRET_ACCESS_KEY="XXXXXXXXX"
+export AWS_SESSION_TOKEN="YYYYYYYYY"
+```
+- To just run unit tests run `mvn test`
+
+### Managed policy union mapper
+- The default mapper allows the mapping to specify different AWS Role, policies etc.
+- The managed policy mapper uses a single AWS Role (specified in config), and the mappings
+just contain a list of Managed Policies.
+- The actual permissions are the union of Managed Policies provided they are allowed by the AWS Role.
+- Changes in user-role-mapper.properties
+
+```
+rolemapper.class.name=com.amazon.aws.emr.mapping.ManagedPolicyBasedUserRoleMapperImpl
+rolemapper.role.arn=arn:aws:iam::<ACC_ID>:role/<BASE_ROLE>
+```
+- Format of JSON file
+
+```
+{
+"PrincipalPolicyMappings": [
+  {
+    "username": "test-user1",
+    "policies": ["arn:aws:iam::176430881729:policy/test-sk-p1"]
+  },
+  {
+    "username": "test-gp1",
+    "policies": ["arn:aws:iam::176430881729:policy/test-sk-p2"]
+  }
+]
+}
+```
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -88,13 +88,18 @@ export AWS_ACCESS_KEY_ID="ASIASSFAZTPATNBHFC56"
 export AWS_SECRET_ACCESS_KEY="XXXXXXXXX"
 export AWS_SESSION_TOKEN="YYYYYYYYY"
 ```
+- The tests run only on OSX and Unix style OS. They skip on other OS.
+- The invoking OS user is used in the tests.
+- The tests create/fetch IAM Roles, Policies, S3 buckets. The caller credentials should have
+permissions to perform these operations.
+- The tests run in lexicographic order, and should be run in a single thread.
 - To just run unit tests run `mvn test`
 
 ### Managed policy union mapper
-- The default mapper allows the mapping to specify different AWS Role, policies etc.
-- The managed policy mapper uses a single AWS Role (specified in config), and the mappings
+- The default mapper allows the mapping to specify different IAM Role, policies etc.
+- The managed policy mapper uses a single IAM Role (specified in config), and the mappings
 just contain a list of Managed Policies.
-- The actual permissions are the union of Managed Policies provided they are allowed by the AWS Role.
+- The actual permissions are the union of Managed Policies provided they are allowed by the IAM Role.
 - Changes in user-role-mapper.properties
 
 ```
@@ -108,11 +113,11 @@ rolemapper.role.arn=arn:aws:iam::<ACC_ID>:role/<BASE_ROLE>
 "PrincipalPolicyMappings": [
   {
     "username": "test-user1",
-    "policies": ["arn:aws:iam::176430881729:policy/test-sk-p1"]
+    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
   },
   {
     "username": "test-gp1",
-    "policies": ["arn:aws:iam::176430881729:policy/test-sk-p2"]
+    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_Y>"]
   }
 ]
 }

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -78,7 +78,7 @@ final public class Constants {
     public static final String PRINCIPAL_RESOLVER_STRATEGY_KEY = "principal.resolver.strategy";
 
     // Default Principal resolver implementation using native system calls
-    public static final String DEFAULT_PRINCIPAL_RESOLVER_STRATEGY = "native";
+    public static final String DEFAULT_PRINCIPAL_RESOLVER_STRATEGY = "command";
 
     public static final String IMPERSONATION_ALLOWED_USERS = "rolemapper.impersonation.allowed.users";
 

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/system/factory/PrincipalResolverFactory.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/system/factory/PrincipalResolverFactory.java
@@ -30,9 +30,9 @@ public class PrincipalResolverFactory implements Factory<PrincipalResolver> {
 
         log.info("Using principal resolver strategy: {}", principalResolverStrategy);
         if (Constants.DEFAULT_PRINCIPAL_RESOLVER_STRATEGY.equalsIgnoreCase(principalResolverStrategy))
-            return new JniBasedPrincipalResolver();
+            return new CommandBasedPrincipalResolver();
 
-        return new CommandBasedPrincipalResolver();
+        return new JniBasedPrincipalResolver();
     }
 
     @Override


### PR DESCRIPTION
2. Updated the README for inetgration tests and managed policy mapper impl.

*Issue #, if available:*
https://github.com/awslabs/amazon-emr-user-role-mapper/issues/20

*Description of changes:*
- Change default principal resolver to Command
- Uodate the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
