### PR TITLE
URM AWS Credentials Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/target/
+**/.idea/
+**/*.iml

--- a/emr-user-role-mapper-application/usr/install/log4j.properties
+++ b/emr-user-role-mapper-application/usr/install/log4j.properties
@@ -5,7 +5,7 @@ log4j.logger.com.amazon.aws.emr=INFO, file
 # Direct log messages to a log file
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 
-log4j.appender.file.File=/emr/user-role-mapper/log/user-role-mapper.log
+log4j.appender.file.File=/emr/user-role-mapper/log/emr-user-role-mapper.log
 log4j.appender.file.MaxFileSize=2MB
 log4j.appender.file.MaxBackupIndex=10
 log4j.appender.file.layout=org.apache.log4j.PatternLayout

--- a/emr-user-role-mapper-credentials-provider/README.md
+++ b/emr-user-role-mapper-credentials-provider/README.md
@@ -1,0 +1,80 @@
+# URM Credentials Provider
+
+This module is necessary if you are going to use URM with Apache PrestoDB/SQL and/or Hive (using impersonation). This credentials provider works by looking at who the current user is using Hadoops UserGroupInformation and retrieves credentials for that user. 
+
+# Setup instructions
+
+## Pre-requistites
+
+- Your cluster must be kerberized and URM must be installed according to the instructions for URM.
+
+## Instructions
+Run:
+```sh
+mvn clean install
+```
+
+and copy target/urm-credentials-provider-0.x-SNAPSHOT-with-dependencies.jar to a location in S3.
+
+Then create a Bootstrap action that does the following:
+
+```bash
+sudo aws s3 cp s3://<location in s3 of jar above> /usr/share/aws/emr/emrfs/auxlib/ 
+```
+
+## EMR Cluster setup
+
+Set the following configuration:
+
+```json
+   {
+       "Classification":"emrfs-site",
+       "Properties":{
+          "fs.s3.customAWSCredentialsProvider":"com.amazonaws.emr.urm.credentialsprovider.URMCredentialsProviderChain"
+       },
+       "Configurations":[
+       ]
+   }
+```
+
+By default, the hive and presto users will use this credentials provider, and everyone else will use the existing DefaultCredentialsProviderChain. If you wish to change this list, add the "urm.credentialsprovider.impersonation.users" property to emrfs-site.xml, like below:
+
+```json
+   {
+       "Classification":"emrfs-site",
+       "Properties":{
+          "fs.s3.customAWSCredentialsProvider":"com.amazonaws.emr.urm.credentialsprovider.URMCredentialsProviderChain",
+          "urm.credentialsprovider.impersonation.users":"hive,presto,admin"
+       },
+       "Configurations":[
+       ]
+   }
+```
+
+## Presto setup
+
+* Set the following configuration:
+
+```json
+   {
+       "Classification":"presto-connector-hive",
+       "Properties":{
+          "hive.hdfs.impersonation.enabled":"true"
+       },
+       "Configurations":[
+       ]
+   }
+```
+
+* "rolemapper.impersonation.allowed.users" property must include "presto" user in your user-role-mapper.properties file to allow presto to impersonate other users.
+
+* When your cluster comes up, ensure that the jar is available as a symlink in /usr/lib/presto/plugin/hive-hadoop2/
+```bash
+ls -lrt /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider*.jar
+lrwxrwxrwx 1 root root 73 Dec 12 02:24 /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider-0.1-SNAPSHOT.jar -> /usr/share/aws/emr/emrfs/auxlib/urm-credentials-provider-0.1-SNAPSHOT.jar
+```
+* If using Glue Data Catalog, there must be a single policy in mappings.json to allow the presto user to access Glue Data Catalog. Presto does not support impersonation when interacting with Metadata services like Glue Data Catalog or Hive Metastore. 
+
+## Hive setup
+
+* "rolemapper.impersonation.allowed.users" property must include "hive" user in your user-role-mapper.properties file to allow hive to impersonate other users.

--- a/emr-user-role-mapper-credentials-provider/pom.xml
+++ b/emr-user-role-mapper-credentials-provider/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazonaws.emr.urm</groupId>
+    <artifactId>urm-credentials-provider</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <name>urm-credentials-provider</name>
+    <description>URM Credentials Provider</description>
+    <url>https://github.com/awslabs/amazon-emr-user-role-mapper/</url>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <dep.hadoop.version>2.8.5</dep.hadoop.version>
+        <dep.aws-sdk.version>1.11.890</dep.aws-sdk.version>
+        <dep.httpclient.version>4.5.13</dep.httpclient.version>
+        <dep.gson.version>2.2.4</dep.gson.version>
+
+        <dep.junit.version>4.12</dep.junit.version>
+        <dep.mockito.version>2.8.9</dep.mockito.version>
+        <dep.powermock.version>1.7.4</dep.powermock.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${dep.aws-sdk.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${dep.hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${dep.httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${dep.gson.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${dep.mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${dep.junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${dep.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${dep.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
+        <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.slf4j:*</exclude>
+                            <exclude>com.fasterxml.*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.code.gson</pattern>
+                            <shadedPattern>com.amazonaws.emr.urm.shaded.com.google.code.gson</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <finalName>urm-credentials-provider-${project.version}-with-dependencies</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/auth/URMCredentialsFetcher.java
+++ b/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/auth/URMCredentialsFetcher.java
@@ -1,0 +1,61 @@
+package com.amazonaws.auth;
+
+import com.amazonaws.internal.EC2ResourceFetcher;
+import com.amazonaws.internal.InstanceMetadataServiceResourceFetcher;
+import com.amazonaws.retry.internal.CredentialsEndpointRetryParameters;
+import com.amazonaws.retry.internal.CredentialsEndpointRetryPolicy;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.net.URI;
+
+/**
+ * This class reuses the {@link BaseCredentialsFetcher} from AWS CLI because it takes care for us:
+ * 1) refreshing credentials automatically when they are close to expiration
+ * 2) parses of the output for credentials and returns the appropriate credentials
+ * 3) makes sure that we conform to the behaviour of the existing instance profile credentials provider.
+ * <p>
+ * This class needed to be in this namespace as the class is package private.
+ */
+public class URMCredentialsFetcher
+        extends BaseCredentialsFetcher
+        implements CredentialsEndpointRetryPolicy
+{
+    final private static String IMPERSONATION_PATH = "http://localhost:9944/latest/meta-data/iam/security-credentials/impersonation/";
+    private URI impersonationURI;
+
+    private final EC2ResourceFetcher resourceFetcher;
+
+    public URMCredentialsFetcher(String user)
+    {
+        this(user, InstanceMetadataServiceResourceFetcher.getInstance());
+    }
+
+    @VisibleForTesting
+    URMCredentialsFetcher(String user, EC2ResourceFetcher ec2ResourceFetcher)
+    {
+        this.impersonationURI = URI.create(IMPERSONATION_PATH + user);
+        this.resourceFetcher = ec2ResourceFetcher;
+    }
+
+    public void setImpersonationUser(String user) {
+        this.impersonationURI = URI.create(IMPERSONATION_PATH + user);
+    }
+
+    @Override
+    protected String getCredentialsResponse()
+    {
+        return resourceFetcher.readResource(impersonationURI, this);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "URMCredentialsFetcher";
+    }
+
+    @Override
+    public boolean shouldRetry(int retriesAttempted, CredentialsEndpointRetryParameters retryParams)
+    {
+        return false;
+    }
+}

--- a/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProvider.java
+++ b/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProvider.java
@@ -1,0 +1,144 @@
+package com.amazonaws.emr.urm.credentialsprovider;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.URMCredentialsFetcher;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class will get credentials from the URM process if the current user is configured
+ * to impersonate the user in the UGI session. This is useful for applications like Presto and
+ * Hive.
+ */
+public class URMCredentialsProvider
+        implements AWSCredentialsProvider
+{
+    static final String EMRFS_SITE_CONF_ALLOWED_USERS = "urm.credentialsprovider.impersonation.users";
+    private static final Log LOG = LogFactory.getLog(URMCredentialsProvider.class);
+    private static final Set<String> DEFAULT_ALLOWED_USERS = new HashSet<>(Arrays.asList("presto", "hive"));
+    private final Set<String> usersAllowedToImpersonate;
+
+    private final String createdBy;
+    private final String createdForUser;
+
+    final private URMCredentialsFetcher urmCredentialsFetcher;
+
+    /**
+     * Default constructor. This constructor will get the current user from the {@link UserGroupInformation} and
+     * uses the default allowed users list.
+     */
+    public URMCredentialsProvider()
+    {
+        this(new URMCredentialsFetcher(getUgi().getShortUserName()),
+                DEFAULT_ALLOWED_USERS,
+                getUgi().getShortUserName(),
+                getUgi().getRealUser().getShortUserName()
+                );
+    }
+
+    /**
+     * This constructor takes a {@link Configuration} and gets the list of users that can impersonate other users.
+     * It will also use the {@link UserGroupInformation} to get the current user.
+     * @param configuration The configuration object that can be passed in to read from.
+     */
+    public URMCredentialsProvider(Configuration configuration)
+    {
+        this(new URMCredentialsFetcher(getUgi().getShortUserName()),
+                getUsersAllowedToImpersonate(configuration),
+                getUgi().getShortUserName(),
+                getUgi().getRealUser().getShortUserName());
+    }
+
+    /**
+     * This constructor takes all members as an argument for testing purposes.
+     * @param urmCredentialsFetcher
+     * @param usersAllowedToImpersonate
+     */
+    @VisibleForTesting
+    URMCredentialsProvider(URMCredentialsFetcher urmCredentialsFetcher, Set<String> usersAllowedToImpersonate,
+            String createdForUser, String realUser)
+    {
+        Preconditions.checkNotNull(urmCredentialsFetcher);
+        Preconditions.checkNotNull(usersAllowedToImpersonate);
+
+        LOG.debug("Building URMCredentials Provider.");
+        this.urmCredentialsFetcher = urmCredentialsFetcher;
+        this.usersAllowedToImpersonate = usersAllowedToImpersonate;
+        this.createdBy = realUser;
+        this.createdForUser = createdForUser;
+    }
+
+    /**
+     * Gets credentials if the real user is allowed to get credentials for an impersonated user.
+     *
+     * @return AWSCredentials if user is allowed to impersonate, null otherwise.
+     */
+    @Override
+    public AWSCredentials getCredentials()
+    {
+        if (!usersAllowedToImpersonate.contains(createdBy)) {
+            //not going to use impersonation for this.
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Not Impersonating as I am: " + createdBy);
+            }
+            //Return null which will then let the existing credentials provider chain to get credentials
+            return null;
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("I am impersonating user: " + createdForUser);
+        }
+        String callingUser = getUgi().getShortUserName();
+        //Put in a safety check here to make sure that this object is created and used. This is to ensure that
+        //credentials leak doesn't happen.
+        if (!callingUser.equalsIgnoreCase(createdForUser) && usersAllowedToImpersonate.contains(callingUser)) {
+            final String errmsg = "Current user is different than calling user! CallingUser: " + callingUser + " CurrentUser: " + createdForUser;
+            LOG.error(errmsg);
+            throw new RuntimeException(errmsg);
+        }
+        return urmCredentialsFetcher.getCredentials();
+    }
+
+    @Override
+    public void refresh()
+    {
+        LOG.debug("Starting to Refreshing Credentials.");
+        urmCredentialsFetcher.refresh();
+        LOG.debug("Finished to Refreshing Credentials.");
+    }
+
+    @VisibleForTesting
+    static Set<String> getUsersAllowedToImpersonate(Configuration configuration)
+    {
+        String[] allowedUsers = configuration.getTrimmedStrings(EMRFS_SITE_CONF_ALLOWED_USERS);
+        if (allowedUsers != null) {
+            return new HashSet<>(Arrays.asList(allowedUsers));
+        }
+        else {
+            return DEFAULT_ALLOWED_USERS;
+        }
+    }
+
+    private static UserGroupInformation getUgi()
+    {
+        try {
+            UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("UGI Returned user : " + ugi.getShortUserName() + " Real User: " + ugi.getRealUser() + " AuthN Method: " + ugi.getAuthenticationMethod());
+            }
+            return ugi;
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to get UGI of the current user.", e);
+        }
+    }
+}

--- a/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderChain.java
+++ b/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderChain.java
@@ -1,0 +1,47 @@
+package com.amazonaws.emr.urm.credentialsprovider;
+
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+
+/**
+ * Provider Chain that adds URM Credentials Provider.
+ */
+public class URMCredentialsProviderChain
+        extends AWSCredentialsProviderChain
+{
+
+    /**
+     * Default constructor that provides the original DefaultCredentialsProviderChain with URMCredentialsProvider as the
+     * first provider.
+     */
+    public URMCredentialsProviderChain()
+    {
+        super(new URMCredentialsProvider(),
+                InstanceProfileCredentialsProvider.getInstance(),
+                new EnvironmentVariableCredentialsProvider(),
+                new SystemPropertiesCredentialsProvider(),
+                new ProfileCredentialsProvider(),
+                new EC2ContainerCredentialsProviderWrapper());
+    }
+
+    /**
+     * Constructor that EMRFS calls and passes in configuration information. It provides the original DefaultCredentialsProviderChain
+     * with URMCredentialsProvider as the first provider.
+     */
+    public URMCredentialsProviderChain(URI uri, Configuration configuration)
+    {
+        super(new URMCredentialsProvider(configuration),
+                InstanceProfileCredentialsProvider.getInstance(),
+                new EnvironmentVariableCredentialsProvider(),
+                new SystemPropertiesCredentialsProvider(),
+                new ProfileCredentialsProvider(),
+                new EC2ContainerCredentialsProviderWrapper());
+    }
+}

--- a/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
+++ b/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
@@ -1,0 +1,92 @@
+package com.amazonaws.emr.urm.credentialsprovider;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.URMCredentialsFetcher;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(UserGroupInformation.class)
+public class URMCredentialsProviderTest
+{
+    public static final String USER = "a_user";
+    public static final String REALUSER = "realuser";
+
+    @Test
+    public void test_nonimpersonation()
+    {
+        URMCredentialsFetcher mockURMCredentialsFetcher = mock(URMCredentialsFetcher.class);
+        URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
+                new HashSet<>(Arrays.asList("user1", "user2")), USER, REALUSER);
+        assertNull(urmCredentialsProvider.getCredentials());
+    }
+
+    @Test
+    public void test_gettingCredentials() throws IOException
+    {
+        // Mock out  URMCredentialsFetcher
+        URMCredentialsFetcher mockURMCredentialsFetcher = mock(URMCredentialsFetcher.class);
+        BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials("accesskey", "secretKey", "sessionToken");
+        when(mockURMCredentialsFetcher.getCredentials()).thenReturn(basicSessionCredentials);
+
+        // Mock out UGI for the impersonated user, and the real user
+        UserGroupInformation mockUgi = mock(UserGroupInformation.class);
+        when(mockUgi.getShortUserName()).thenReturn(USER);
+
+        UserGroupInformation mockRealUserUGI = mock(UserGroupInformation.class);
+        when(mockUgi.getRealUser()).thenReturn(mockRealUserUGI);
+        when(mockRealUserUGI.getShortUserName()).thenReturn(REALUSER);
+
+        // Mock out UGI singleton
+        PowerMockito.mockStatic(UserGroupInformation.class);
+        BDDMockito.given(UserGroupInformation.getCurrentUser()).willReturn(mockUgi);
+        when(mockUgi.getRealUser()).thenReturn(mockRealUserUGI);
+
+        Set<String> allowedList = new HashSet<>(Collections.singletonList(REALUSER));
+        URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
+                allowedList, USER, REALUSER);
+
+        AWSCredentials returnedCreds = urmCredentialsProvider.getCredentials();
+
+        assertNotNull(returnedCreds);
+        assertTrue(returnedCreds instanceof BasicSessionCredentials);
+        assertEquals(basicSessionCredentials.getAWSAccessKeyId(), returnedCreds.getAWSAccessKeyId());
+        assertEquals(basicSessionCredentials.getAWSSecretKey(), returnedCreds.getAWSSecretKey());
+        assertEquals(basicSessionCredentials.getSessionToken(), ((BasicSessionCredentials) returnedCreds).getSessionToken());
+    }
+
+    @Test
+    public void test_AllowListFromConfiguration()
+    {
+        Configuration mockConfiguration = mock(Configuration.class);
+        when(mockConfiguration.getTrimmedStrings(URMCredentialsProvider.EMRFS_SITE_CONF_ALLOWED_USERS))
+                .thenReturn(new String[] {"user1", "user2"});
+
+        Set<String> users = URMCredentialsProvider.getUsersAllowedToImpersonate(mockConfiguration);
+
+        assertNotNull(users);
+        assertEquals(2, users.size());
+        assertTrue(users.contains("user1"));
+        assertTrue(users.contains("user2"));
+    }
+}


### PR DESCRIPTION
A custom credentials provider that will call URM's impersonation API's for trusted processes like hive and presto to get credentials on behalf of the end user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
