### PR TITLE
UGI.getRealUser() may sometimes return null which causes NPE. 

### DIFF
--- a/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
+++ b/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
@@ -89,4 +89,19 @@ public class URMCredentialsProviderTest
         assertTrue(users.contains("user1"));
         assertTrue(users.contains("user2"));
     }
+
+    @Test
+    public void test_ugiReturnNull() throws IOException
+    {
+        UserGroupInformation mockUgi = mock(UserGroupInformation.class);
+        when(mockUgi.getRealUser()).thenReturn(null);
+
+        PowerMockito.mockStatic(UserGroupInformation.class);
+        BDDMockito.given(UserGroupInformation.getCurrentUser()).willReturn(mockUgi);
+
+        String realUser = URMCredentialsProvider.getRealUser();
+
+        assertNotNull(realUser);
+        assertEquals(System.getProperty("user.name"), realUser);
+    }
 }


### PR DESCRIPTION
This code will attempt to use getRealUser() and if it returns null, use System.getProperty("user.name") instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
