### PR TITLE
Changed URM Credentials provider so it does not remember the impersonated user on create

### DIFF
--- a/emr-user-role-mapper-credentials-provider/README.md
+++ b/emr-user-role-mapper-credentials-provider/README.md
@@ -53,6 +53,8 @@ By default, the hive and presto users will use this credentials provider, and ev
 
 ## Presto setup
 
+### General Instructions
+
 * Set the following configuration:
 
 ```json
@@ -73,7 +75,46 @@ By default, the hive and presto users will use this credentials provider, and ev
 ls -lrt /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider*.jar
 lrwxrwxrwx 1 root root 73 Dec 12 02:24 /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider-0.1-SNAPSHOT.jar -> /usr/share/aws/emr/emrfs/auxlib/urm-credentials-provider-0.1-SNAPSHOT.jar
 ```
-* If using Glue Data Catalog, there must be a single policy in mappings.json to allow the presto user to access Glue Data Catalog. Presto does not support impersonation when interacting with Metadata services like Glue Data Catalog or Hive Metastore. 
+
+* IMPORTANT: Presto does not support impersonation when interacting with Metadata services like Glue Data Catalog or Hive Metastore. Trino does and support for it is coming.
+
+### Using Glue Data Catalog as your meta store.
+
+If using Glue Data Catalog, there must be a single policy in mappings.json to allow the presto user to access Glue Data Catalog.  
+
+For example:
+
+```json
+{
+"PrincipalPolicyMappings": [
+  {
+    "username": "presto",
+    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
+  }
+}
+
+where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.
+
+#### Note: As of PrestoDB 0.232, it does not perform the necessary impersonation in rare cases which is why s3:ListBucket permissions is needed. 
+```
+
+### Using Hive Metastore
+
+Presto does not support impersonation when interacting with Hive Metastore. For this reason, the presto user will need to have a mapping to a role that has access to S3. 
+
+```json
+{
+"PrincipalPolicyMappings": [
+  {
+    "username": "hive",
+    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
+  }
+}
+
+where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.
+```
+
+Also, if you are using StorageBasedAuthorizer as the authorization layer for Hive Metastore, you will need to provide S3 privileges to the presto user as well. This is so that the authorizer can access S3 during it's authorization checks.
 
 ## Hive setup
 

--- a/emr-user-role-mapper-credentials-provider/README.md
+++ b/emr-user-role-mapper-credentials-provider/README.md
@@ -92,11 +92,11 @@ For example:
     "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
   }
 }
+```
 
 where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.
 
-#### Note: As of PrestoDB 0.232, it does not perform the necessary impersonation in rare cases which is why s3:ListBucket permissions is needed. 
-```
+Note: As of PrestoDB 0.232, it does not perform the necessary impersonation in rare cases which is why s3:ListBucket permissions is needed. 
 
 ### Using Hive Metastore
 
@@ -111,8 +111,9 @@ Presto does not support impersonation when interacting with Hive Metastore. For 
   }
 }
 
-where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.
 ```
+
+where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.
 
 Also, if you are using StorageBasedAuthorizer as the authorization layer for Hive Metastore, you will need to provide S3 privileges to the presto user as well. This is so that the authorizer can access S3 during it's authorization checks.
 

--- a/emr-user-role-mapper-credentials-provider/README.md
+++ b/emr-user-role-mapper-credentials-provider/README.md
@@ -86,11 +86,12 @@ For example:
 
 ```json
 {
-"PrincipalPolicyMappings": [
-  {
-    "username": "presto",
-    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
-  }
+    "PrincipalPolicyMappings": [
+      {
+        "username": "presto",
+        "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
+      }
+    ]
 }
 ```
 
@@ -104,13 +105,13 @@ Presto does not support impersonation when interacting with Hive Metastore. For 
 
 ```json
 {
-"PrincipalPolicyMappings": [
-  {
-    "username": "hive",
-    "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
-  }
+    "PrincipalPolicyMappings": [
+      {
+        "username": "hive",
+        "policies": ["arn:aws:iam::<ACC-ID>:policy/<POLICY_X>"]
+      }
+    ]
 }
-
 ```
 
 where POLICY_X is a policy that has access to Glue Data Catalog and s3:ListBucket for any s3 buckets that you wish Presto to access.

--- a/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
+++ b/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
@@ -37,7 +37,7 @@ public class URMCredentialsProviderTest
     {
         URMCredentialsFetcher mockURMCredentialsFetcher = mock(URMCredentialsFetcher.class);
         URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
-                new HashSet<>(Arrays.asList("user1", "user2")), USER, REALUSER);
+                new HashSet<>(Arrays.asList("user1", "user2")), REALUSER);
         assertNull(urmCredentialsProvider.getCredentials());
     }
 
@@ -64,7 +64,7 @@ public class URMCredentialsProviderTest
 
         Set<String> allowedList = new HashSet<>(Collections.singletonList(REALUSER));
         URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
-                allowedList, USER, REALUSER);
+                allowedList, REALUSER);
 
         AWSCredentials returnedCreds = urmCredentialsProvider.getCredentials();
 


### PR DESCRIPTION
Changed URM Credentials provider so it does not remember the impersonated user on create, rather vend credentials always based on the current impersonated user via UGI. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
