### PR TITLE
Added No Match AWS IAM policy

### DIFF
--- a/emr-user-role-mapper-application/pom.xml
+++ b/emr-user-role-mapper-application/pom.xml
@@ -223,6 +223,7 @@
         <!-- Separates the unit tests from the integration tests. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
         <configuration>
           <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
           <skip>true</skip>

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMappings.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/model/PrincipalPolicyMappings.java
@@ -8,6 +8,9 @@ import lombok.Data;
 
 @Data
 public class PrincipalPolicyMappings {
+    @SerializedName("NoMatchPolicyArn")
+    String noMatchPolicyArn;
+
     @SerializedName("PrincipalPolicyMappings")
     PrincipalPolicyMapping[] principalPolicyMappings;
 }

--- a/emr-user-role-mapper-application/src/test-data/log4j.properties
+++ b/emr-user-role-mapper-application/src/test-data/log4j.properties
@@ -1,5 +1,4 @@
-log4j.rootCategory=DEBUG,console
-log4j.logger.com.amazon.emr=DEBUG,console
+log4j.rootCategory=INFO,console
 log4j.additivity.com.amazon.emr=false
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
@@ -8,3 +7,5 @@ log4j.appender.console.encoding=UTF-8
 #log4j.appender.console.threshold=warn
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.conversionPattern=%d [%t] %-5p %c - %m%n
+
+log4j.logger.com.amazon.emr=DEBUG,console

--- a/emr-user-role-mapper-application/src/test-data/user-role-mapper.properties
+++ b/emr-user-role-mapper-application/src/test-data/user-role-mapper.properties
@@ -1,2 +1,2 @@
 rolemapper.class.name=com.amazon.aws.emr.mapping.TestUserRoleMapperImpl
-rolemapper.impersonation.allowed.users=hive,   presto
+rolemapper.impersonation.allowed.users=hive,presto

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/defaultmapper/DefaultMappingProviderImplIntegrationTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/defaultmapper/DefaultMappingProviderImplIntegrationTest.java
@@ -133,6 +133,8 @@ public class DefaultMappingProviderImplIntegrationTest extends IntegrationTestBa
     if (testRoleArn != null) {
       IAMUtils.deleteRole(testRoleName);
     }
+    //Give time for IAM to delete the role before the policy can be deleted.
+    Thread.sleep(2 * 1000);
     if (testPolicyArn != null) {
       IAMUtils.deletePolicy(testPolicyArn);
     }

--- a/emr-user-role-mapper-credentials-provider/README.md
+++ b/emr-user-role-mapper-credentials-provider/README.md
@@ -76,7 +76,9 @@ ls -lrt /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider*.jar
 lrwxrwxrwx 1 root root 73 Dec 12 02:24 /usr/lib/presto/plugin/hive-hadoop2/urm-credentials-provider-0.1-SNAPSHOT.jar -> /usr/share/aws/emr/emrfs/auxlib/urm-credentials-provider-0.1-SNAPSHOT.jar
 ```
 
-* IMPORTANT: Presto does not support impersonation when interacting with Metadata services like Glue Data Catalog or Hive Metastore. Trino does and support for it is coming.
+* **IMPORTANT: Presto does not support impersonation when interacting with Metadata services like Glue Data Catalog or Hive Metastore. Trino does and support for it is coming.**
+
+* **IMPORTANT: Impersonation is not supported when S3 Select Predicate Push down is enabled. Ensure that its not enabled.**
 
 ### Using Glue Data Catalog as your meta store.
 


### PR DESCRIPTION
### Description
Added the ability to add a default Policy that can be attached IF no other matches were found. It defaults to AWSDenyAll AWS managed policy but can be overwritten.

The reason why this is needed is because within the Credentials Provider, if no credentials are returned by URM Credentials Provider, then the provider chain will go to the next provider, ie Profile Instance Provider, and will use that provider going forward without going back to the URM provider. It also provides a clear message to users that all access is being blocked and that they don't have access.

### Testing:
Unit test
Tested on my own cluster
Tests and unit tests pass: mvn clean integration-tests

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.612 s - in com.amazon.aws.emr.credentials.STSCredentialsProviderTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
....
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 145.371 s - in com.amazon.aws.emr.integration.policyunionmapper.PoliciesUnionMappingProviderImplIntegrationTest
[[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 75.376 s - in com.amazon.aws.emr.integration.defaultmapper.DefaultMappingProviderImplIntegrationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
....
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:36 min
[INFO] Finished at: 2021-02-12T11:24:39-05:00
[INFO] ------------------------------------------------------------------------

```