### PR TITLE
Fix Installation Problems By Updating JAR Version Number References

### DIFF
--- a/emr-user-role-mapper-application/pom.xml
+++ b/emr-user-role-mapper-application/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.amazonaws.emr</groupId>
       <artifactId>emr-user-role-mapper-provider</artifactId>
-      <version>1.0</version>
+      <version>1.1.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/emr-user-role-mapper-application/usr/install/ba-script.sh
+++ b/emr-user-role-mapper-application/usr/install/ba-script.sh
@@ -186,8 +186,8 @@ sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/user-role-mapper.properties /emr/user-r
 echo "Getting and setting mappings.json"
 sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/mappings.json /emr/user-role-mapper/conf/
 sudo sed -i "s#\$AWS_ROLE#${ROLE_ARN}#g" /emr/user-role-mapper/conf/mappings.json
-echo "Getting emr-user-role-mapper-application-1.0-jar-with-dependencies-and-exclude-classes.jar from S3"
-sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/emr-user-role-mapper-application-1.0-jar-with-dependencies-and-exclude-classes.jar /usr/share/aws/emr/user-role-mapper/lib/
+echo "Getting emr-user-role-mapper-application-1.1.0-jar-with-dependencies-and-exclude-classes.jar from S3"
+sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/emr-user-role-mapper-application-1.1.0-jar-with-dependencies-and-exclude-classes.jar /usr/share/aws/emr/user-role-mapper/lib/
 
 echo "Setting permissions"
 sudo chown -R userrolemapper:$sudo_user /emr/user-role-mapper


### PR DESCRIPTION
`mvn clean install` from the master branch does not work. It looks like one <version> was not upgraded from 1.0 to 1.1.0.  This fix allows for maven to build.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
