### PR TITLE
Added optional support for sts:SourceIdentity to enable auditing base…

### DIFF
--- a/emr-user-role-mapper-application/pom.xml
+++ b/emr-user-role-mapper-application/pom.xml
@@ -14,7 +14,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <aws-java-sdk.version>1.11.896</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.22</aws-java-sdk.version>
     <guava.version>[24.1.1,)</guava.version>
     <gson.version>2.8.5</gson.version>
     <java.version>1.8</java.version>

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
@@ -100,6 +100,12 @@ public class ApplicationConfiguration {
     public Set<String> getAllowedUsersForImpersonation() {
         return this.IMPERSONATION_ALLOWED_USERS;
     }
+
+    public boolean isSetSourceIdentityEnabled() {
+        return Boolean.parseBoolean(properties.getProperty(Constants.SET_SOURCE_IDENTITY_ENABLED,
+            String.valueOf("false")));
+    }
+
     public Map<String, String> asMap() {
         return Maps.fromProperties(properties);
     }

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -82,6 +82,9 @@ final public class Constants {
 
     public static final String IMPERSONATION_ALLOWED_USERS = "rolemapper.impersonation.allowed.users";
 
+    // Set the source identity in the Assume Role calls
+    public static final String SET_SOURCE_IDENTITY_ENABLED = "rolemapper.sourceidentity.enabled";
+
     private Constants() {
     }
 

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/MappingInvoker.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/MappingInvoker.java
@@ -103,15 +103,8 @@ public class MappingInvoker {
             Optional<AssumeRoleRequest> assumeRoleRequest = roleMapperProvider.getMapping(username);
             if (assumeRoleRequest.isPresent() && applicationConfiguration.isSetSourceIdentityEnabled()) {
                 assumeRoleRequest.get().setSourceIdentity(username);
-<<<<<<< HEAD
             }
             log.debug("Found mapping for {} as {}", username, assumeRoleRequest);
-=======
-            } else {
-                log.info("Not setting source identity");
-            }
-            log.info("Found mapping for {} as {}", username, assumeRoleRequest);
->>>>>>> 62d67f4a23a1a4a13d3436b254642786f891bfd5
             return assumeRoleRequest;
         } catch (Throwable t) {
             // We are running some custom code that could throw anything.

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/MappingInvoker.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/mapping/MappingInvoker.java
@@ -101,6 +101,9 @@ public class MappingInvoker {
         readLockInRwLock.lock();
         try {
             Optional<AssumeRoleRequest> assumeRoleRequest = roleMapperProvider.getMapping(username);
+            if (assumeRoleRequest.isPresent() && applicationConfiguration.isSetSourceIdentityEnabled()) {
+                assumeRoleRequest.get().setSourceIdentity(username);
+            }
             log.debug("Found mapping for {} as {}", username, assumeRoleRequest);
             return assumeRoleRequest;
         } catch (Throwable t) {

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/MappingInvokerTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/mapping/MappingInvokerTest.java
@@ -3,17 +3,32 @@ package com.amazon.aws.emr.mapping;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import com.amazon.aws.emr.ApplicationConfiguration;
 import com.amazon.aws.emr.common.Constants;
+import com.amazon.aws.emr.rolemapper.UserRoleMapperProvider;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import java.util.Optional;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @RunWith(MockitoJUnitRunner.class)
 public class MappingInvokerTest {
 
-  MappingInvoker mappingInvoker = new MappingInvoker();
+  private static final String TEST_USER = "test-user";
+  @Mock
+  UserRoleMapperProvider roleMapperProvider;
+  @Mock
+  ApplicationConfiguration applicationConfiguration;
+  @InjectMocks
+  MappingInvoker mappingInvoker;
 
   @Test
   public void is_s3_based_impl() {
@@ -24,4 +39,25 @@ public class MappingInvokerTest {
         mappingInvoker.isS3BasedProviderImpl(Constants.ROLE_MAPPING_MANAGED_POLICY_CLASSNAME),
         is(true));
   }
+
+  @Test
+  public void source_identity_enabled_then_injected() {
+    AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest().withRoleArn("test-arn");
+    when(roleMapperProvider.getMapping(TEST_USER)).thenReturn(Optional.of(assumeRoleRequest));
+    when(applicationConfiguration.isSetSourceIdentityEnabled()).thenReturn(true);
+    Optional<AssumeRoleRequest> actual = mappingInvoker.map(TEST_USER);
+    assertThat(actual.isPresent(), is(true));
+    assertThat(actual.get(), is(assumeRoleRequest.withSourceIdentity(TEST_USER)));
+  }
+
+  @Test
+  public void source_identity_disabled_then_not_injected() {
+    AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest().withRoleArn("test-arn");
+    when(roleMapperProvider.getMapping(TEST_USER)).thenReturn(Optional.of(assumeRoleRequest));
+    when(applicationConfiguration.isSetSourceIdentityEnabled()).thenReturn(false);
+    Optional<AssumeRoleRequest> actual = mappingInvoker.map(TEST_USER);
+    assertThat(actual.isPresent(), is(true));
+    assertThat(actual.get(), is(assumeRoleRequest));
+  }
+
 }


### PR DESCRIPTION
…d on immutable sts:SourceIdentity.

*Issue #, https://github.com/awslabs/amazon-emr-user-role-mapper/issues/37

*Description of changes:*

- Adds an optional config parameter that enables adding STS SourceIdentity in the AssumeRole calls
- The caller needs to have permissions to `SetSourceIdentity` and the assume role should also trust the caller to set the source identity

- Testing
-  Created a cluster with URM.
- Enabled the new sts:AssumeRole feature
```
 cat /emr/user-role-mapper/conf/user-role-mapper.properties 
#rolemapper.class.name=com.mycompany.mapper.RoleMapperImpl
rolemapper.s3.bucket=my-custom-mapper
rolemapper.s3.key=test.json
rolemapper.sourceidentity.enabled=true
rolemapper.refresh.interval.minutes=1
rolemapper.max.threads=35
rolemapper.min.threads=15
``` 
- Tested with CLI for two roles. One that allows setting source identity, another doesn't
```
[hadoop@ip-10-35-205-169 ~]$ sudo -u sharad1 aws sts get-caller-identity
{
    "Account": "176430881729", 
    "UserId": "AROASSFAZTPA6YOSG5O4F:sharad1", 
    "Arn": "arn:aws:sts::176430881729:assumed-role/test-emr-sk1/sharad1"
}
[hadoop@ip-10-35-205-169 ~]$ sudo -u sharad2 aws sts get-caller-identity
Unable to locate credentials. You can configure credentials by running "aws configure".
```
- Error in logs
```
AWS Service exception User: arn:aws:sts::176430881729:assumed-role/EMR_EC2_DefaultRole/i-0a814066f8bf3c053 is not authorized to perform: sts:SetSourceIdentity on resource: arn:aws:iam::176430881729:role/read-s3-role
com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException: User: arn:aws:sts::176430881729:assumed-role/EMR_EC2_DefaultRole/i-0a814066f8bf3c053 is not authorized to perform: sts:SetSourceIdentity on resource: arn:aws:iam::176430881729:role/read-s3-role (Service: AWSSecurityTokenService; Status Code: 403; Error Code: AccessDenied; Request ID: 1c5c4e84-d1c4-44ae-9386-9f1a7811fe4d; Proxy: null)

```