### PR TITLE
We will use the regional endpoint with STS whenever possible.

### DIFF
--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
@@ -101,6 +101,12 @@ public class ApplicationConfiguration {
         return this.IMPERSONATION_ALLOWED_USERS;
     }
 
+    public boolean isRegionalStsEnabled() {
+        return Boolean.parseBoolean(properties.getProperty(Constants.REGIONAL_STS_ENABLED,
+            String.valueOf("true")));
+    }
+
+
     public boolean isSetSourceIdentityEnabled() {
         return Boolean.parseBoolean(properties.getProperty(Constants.SET_SOURCE_IDENTITY_ENABLED,
             String.valueOf("false")));

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ApplicationConfiguration.java
@@ -102,7 +102,7 @@ public class ApplicationConfiguration {
     }
 
     public boolean isRegionalStsEnabled() {
-        return Boolean.parseBoolean(properties.getProperty(Constants.REGIONAL_STS_ENABLED,
+        return Boolean.parseBoolean(properties.getProperty(Constants.REGIONAL_STS_ENDPOINT_ENABLED,
             String.valueOf("true")));
     }
 

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -85,7 +85,9 @@ final public class Constants {
     // Set the source identity in the Assume Role calls
     public static final String SET_SOURCE_IDENTITY_ENABLED = "rolemapper.sourceidentity.enabled";
 
-    public static final String REGIONAL_STS_ENABLED = "rolemapper.regional.sts.enabled";
+    // Determines if regional STS endpoint is used. Setting to "false" uses global endpoint.
+    // Default value is true.
+    public static final String REGIONAL_STS_ENDPOINT_ENABLED = "rolemapper.regional.sts.endpoint.enabled";
 
     private Constants() {
     }

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -85,6 +85,8 @@ final public class Constants {
     // Set the source identity in the Assume Role calls
     public static final String SET_SOURCE_IDENTITY_ENABLED = "rolemapper.sourceidentity.enabled";
 
+    public static final String REGIONAL_STS_ENABLED = "rolemapper.regional.sts.enabled";
+
     private Constants() {
     }
 

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClient.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClient.java
@@ -1,0 +1,10 @@
+package com.amazon.aws.emr.credentials;
+
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+
+
+public interface STSClient {
+
+  AssumeRoleResult assumeRole(AssumeRoleRequest assumeRoleRequest);
+}

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClient.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClient.java
@@ -3,8 +3,10 @@ package com.amazon.aws.emr.credentials;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 
-
+/**
+ * Interface representing the AWS STS client.
+ */
 public interface STSClient {
-
+  
   AssumeRoleResult assumeRole(AssumeRoleRequest assumeRoleRequest);
 }

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
@@ -35,21 +35,26 @@ public class STSClientImpl implements STSClient {
       try {
         region = Regions.getCurrentRegion();
         regionString = region.getName();
+        String endpoint = String.format("https://sts.%s.amazonaws.com", regionString);
+        log.info("Running the application with regional STS endpoint " + endpoint);
+        stsClient = AWSSecurityTokenServiceClientBuilder
+            .standard()
+            .withEndpointConfiguration(new EndpointConfiguration(endpoint, regionString))
+            .build();
       } catch (Exception e) {
-        log.error("Cannot determine the AWS region. Defaulting to {}", regionString);
+        log.error("Cannot determine the AWS region. Defaulting to global endpoint.");
+        createGlobalEndpointClient();
       }
-      String endpoint = String.format("https://sts.%s.amazonaws.com", regionString);
-      log.info("Running the application with regional STS endpoint " + endpoint);
-      stsClient = AWSSecurityTokenServiceClientBuilder
-          .standard()
-          .withEndpointConfiguration(new EndpointConfiguration(endpoint, regionString))
-          .build();
     } else {
-      log.info("Running the application with global STS endpoint.");
-      stsClient = AWSSecurityTokenServiceClientBuilder
-          .standard()
-          .build();
+      createGlobalEndpointClient();
     }
+  }
+
+  private void createGlobalEndpointClient() {
+    log.info("Running the application with global STS endpoint.");
+    stsClient = AWSSecurityTokenServiceClientBuilder
+        .standard()
+        .build();
   }
 
   @Override

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
@@ -1,0 +1,56 @@
+package com.amazon.aws.emr.credentials;
+
+import com.amazon.aws.emr.ApplicationConfiguration;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.glassfish.hk2.api.Immediate;
+
+@Slf4j
+@Immediate
+public class STSClientImpl implements STSClient {
+  // If using regional configurations we will use us-west-2 as default
+  // This is primarily used in integration tests
+  private String regionString = "us-west-2";
+
+  @Inject
+  ApplicationConfiguration applicationConfiguration;
+
+  AWSSecurityTokenService stsClient;
+
+  @PostConstruct
+  void init() {
+    if (applicationConfiguration.isRegionalStsEnabled()) {
+      Region region = null;
+      try {
+        region = Regions.getCurrentRegion();
+        regionString = region.getName();
+      } catch (Exception e) {
+        log.error("Cannot determine the AWS region. Defaulting to {}", regionString);
+      }
+      String endpoint = String.format("https://sts.%s.amazonaws.com", regionString);
+      log.info("Running the application with regional STS endpoint " + endpoint);
+      stsClient = AWSSecurityTokenServiceClientBuilder
+          .standard()
+          .withEndpointConfiguration(new EndpointConfiguration(endpoint, regionString))
+          .build();
+    } else {
+      log.info("Running the application with global STS endpoint.");
+      stsClient = AWSSecurityTokenServiceClientBuilder
+          .standard()
+          .build();
+    }
+  }
+
+  @Override
+  public AssumeRoleResult assumeRole(AssumeRoleRequest assumeRoleRequest) {
+    return stsClient.assumeRole(assumeRoleRequest);
+  }
+}

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSClientImpl.java
@@ -13,6 +13,9 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.hk2.api.Immediate;
 
+/**
+ * Creates a custom AWS STS client based on {@link ApplicationConfiguration}
+ */
 @Slf4j
 @Immediate
 public class STSClientImpl implements STSClient {

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSCredentialsProvider.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/credentials/STSCredentialsProvider.java
@@ -43,8 +43,6 @@ public class STSCredentialsProvider implements MetadataCredentialsProvider {
     public static final Duration MIN_REMAINING_TIME_TO_REFRESH_CREDENTIALS = Duration.ofMinutes(10);
     public static final Duration MAX_RANDOM_TIME_TO_REFRESH_CREDENTIALS = Duration.ofMinutes(5);
     private static final int CREDENTIALS_MAP_MAX_SIZE = 20000;
-    // Initialized later for testing using mocks.
-    public static Region region = null;
 
     private final LoadingCache<AssumeRoleRequest, Optional<EC2MetadataUtils.IAMSecurityCredential>> credentialsCache = CacheBuilder
         .newBuilder().maximumSize(CREDENTIALS_MAP_MAX_SIZE)

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ws/UserRoleMapperBinder.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/ws/UserRoleMapperBinder.java
@@ -7,6 +7,8 @@ import com.amazon.aws.emr.ApplicationConfiguration;
 import com.amazon.aws.emr.common.system.PrincipalResolver;
 import com.amazon.aws.emr.common.system.factory.PrincipalResolverFactory;
 import com.amazon.aws.emr.credentials.MetadataCredentialsProvider;
+import com.amazon.aws.emr.credentials.STSClient;
+import com.amazon.aws.emr.credentials.STSClientImpl;
 import com.amazon.aws.emr.credentials.STSCredentialsProvider;
 import com.amazon.aws.emr.mapping.MappingInvoker;
 import com.amazon.aws.emr.common.system.user.LinuxUserIdService;
@@ -27,6 +29,7 @@ public class UserRoleMapperBinder extends AbstractBinder {
         bind(MappingInvoker.class).to(MappingInvoker.class).in(Immediate.class);
         bind(STSCredentialsProvider.class).to(MetadataCredentialsProvider.class).in(Singleton.class);
         bind(ApplicationConfiguration.class).to(ApplicationConfiguration.class).in(Immediate.class);
+        bind(STSClientImpl.class).to(STSClient.class).in(Immediate.class);
         bindFactory(PrincipalResolverFactory.class).to(PrincipalResolver.class).in(Singleton.class);
     }
 }

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/defaultmapper/DefaultMapperIntegrationBinder.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/defaultmapper/DefaultMapperIntegrationBinder.java
@@ -8,6 +8,8 @@ import com.amazon.aws.emr.common.system.PrincipalResolver;
 import com.amazon.aws.emr.common.system.impl.CommandBasedPrincipalResolver;
 import com.amazon.aws.emr.common.system.user.UserIdService;
 import com.amazon.aws.emr.credentials.MetadataCredentialsProvider;
+import com.amazon.aws.emr.credentials.STSClient;
+import com.amazon.aws.emr.credentials.STSClientImpl;
 import com.amazon.aws.emr.credentials.STSCredentialsProvider;
 import com.amazon.aws.emr.integration.IntegrationTestsUserService;
 import com.amazon.aws.emr.mapping.MappingInvoker;
@@ -24,6 +26,7 @@ public class DefaultMapperIntegrationBinder extends AbstractBinder {
   protected void configure() {
     bind(IntegrationTestsUserService.class).to(UserIdService.class);
     bind(MappingInvoker.class).to(MappingInvoker.class).in(Immediate.class);
+    bind(STSClientImpl.class).to(STSClient.class).in(Immediate.class);
     bind(STSCredentialsProvider.class).to(MetadataCredentialsProvider.class).in(Singleton.class);
     bind(DefaultMapperImplApplicationConfig.class).to(ApplicationConfiguration.class)
         .in(Immediate.class);

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/policyunionmapper/PoliciesUnionMapperIntegrationBinder.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/policyunionmapper/PoliciesUnionMapperIntegrationBinder.java
@@ -8,6 +8,8 @@ import com.amazon.aws.emr.common.system.PrincipalResolver;
 import com.amazon.aws.emr.common.system.impl.CommandBasedPrincipalResolver;
 import com.amazon.aws.emr.common.system.user.UserIdService;
 import com.amazon.aws.emr.credentials.MetadataCredentialsProvider;
+import com.amazon.aws.emr.credentials.STSClient;
+import com.amazon.aws.emr.credentials.STSClientImpl;
 import com.amazon.aws.emr.credentials.STSCredentialsProvider;
 import com.amazon.aws.emr.integration.IntegrationTestsUserService;
 import com.amazon.aws.emr.mapping.MappingInvoker;
@@ -24,6 +26,7 @@ public class PoliciesUnionMapperIntegrationBinder extends AbstractBinder {
   protected void configure() {
     bind(IntegrationTestsUserService.class).to(UserIdService.class);
     bind(MappingInvoker.class).to(MappingInvoker.class).in(Immediate.class);
+    bind(STSClientImpl.class).to(STSClient.class).in(Immediate.class);
     bind(STSCredentialsProvider.class).to(MetadataCredentialsProvider.class).in(Singleton.class);
     bind(PoliciesUnionMapperImplApplicationConfig.class).to(ApplicationConfiguration.class)
         .in(Immediate.class);


### PR DESCRIPTION
The global endpoint is used in case the region cannot be found.

https://github.com/awslabs/amazon-emr-user-role-mapper/issues/44

*Issue #, if available:*

*Testing:*

- Integration tests succeeded
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Amazon EMR User Role Mapper 1.2.0-SNAPSHOT:
[INFO] 
[INFO] Amazon EMR User Role Mapper ........................ SUCCESS [  0.273 s]
[INFO] Amazon EMR User Role Mapper Interface .............. SUCCESS [  1.130 s]
[INFO] Amazon EMR User Role Mapper Application ............ SUCCESS [04:35 min]
[INFO] Amazon EMR User Role Mapper URM Credentials Provider SUCCESS [  5.661 s]
[INFO] Amazon EMR User Role Mapper S3 Storage Based Authorizer for Hive SUCCESS [ 13.551 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:56 min
[INFO] Finished at: 2021-09-28T14:43:39-07:00
[INFO] ------------------------------------------------------------------------

```

- Old functionality in place
```
sudo -u sharad1 aws sts get-caller-identity
{
    "Account": "176430881729", 
    "UserId": "AROASSFAZTPA6YOSG5O4F:sharad1", 
    "Arn": "arn:aws:sts::176430881729:assumed-role/test-emr-sk1/sharad1"
}

```

- Logs showing we now use the regional STS endpoint
```
2021-09-28 18:14:30 worker-thread-16 DEBUG PoolingHttpClientConnectionManager:267 - Connection request: [route: {s}->https://sts.us-east-1.amazonaws.com:443][total available: 0; route allocated: 0 of 50; total allocated: 0 of 50]
2021-09-28 18:14:30 worker-thread-16 DEBUG PoolingHttpClientConnectionManager:312 - Connection leased: [id: 1][route: {s}->https://sts.us-east-1.amazonaws.com:443][total available: 0; route allocated: 1 of 50; total allocated: 1 of 50]
2021-09-28 18:14:30 worker-thread-16 DEBUG MainClientExec:234 - Opening connection {s}->https://sts.us-east-1.amazonaws.com:443
2021-09-28 18:14:30 worker-thread-16 DEBUG DefaultHttpClientConnectionOperator:139 - Connecting to sts.us-east-1.amazonaws.com/54.239.24.200:443
2021-09-28 18:14:30 worker-thread-16 DEBUG SdkTLSSocketFactory:137 - connecting to sts.us-east-1.amazonaws.com/54.239.24.200:443

2021-09-28 18:14:30 worker-thread-16 DEBUG DefaultHttpClientConnectionOperator:146 - Connection established 10.81.172.210:56588<->54.239.24.200:443
2021-09-28 18:14:30 worker-thread-16 DEBUG DefaultManagedHttpClientConnection:88 - http-outgoing-1: set socket timeout to 50000
2021-09-28 18:14:30 worker-thread-16 DEBUG MainClientExec:255 - Executing request POST / HTTP/1.1
2021-09-28 18:14:30 worker-thread-16 DEBUG MainClientExec:266 - Proxy auth state: UNCHALLENGED
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:133 - http-outgoing-1 >> POST / HTTP/1.1
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> Host: sts.us-east-1.amazonaws.com
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> amz-sdk-invocation-id: 50cb1962-198e-64c4-769b-9d76145a94e9
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> amz-sdk-request: attempt=1;max=4
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> amz-sdk-retry: 0/0/500
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> Authorization: AWS4-HMAC-SHA256 Credential=ASIASSFAZTPATNCJLB43/20210928/us-east-1/sts/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;amz-sdk-retry;host;user-agent;x-amz-date;x-amz-security-token, Signature=8cee0e8701eacd9f8c8960647963e6a6998f4bca125180b4ce538e496dad2f58
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> User-Agent: aws-sdk-java/1.12.22 Linux/4.14.154-99.181.amzn1.x86_64 OpenJDK_64-Bit_Server_VM/25.302-b08 java/1.8.0_302 vendor/Red_Hat,_Inc. cfg/retry-mode/legacy
2021-09-28 18:14:30 worker-thread-16 DEBUG headers:136 - http-outgoing-1 >> X-Amz-Date: 20210928T181430Z
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
