### PR TITLE
[Glue] Add Credentials Provider Factory for AWS Glue Hive Metastore C…

### DIFF
--- a/emr-user-role-mapper-s3storagebasedauthorizationmanager/pom.xml
+++ b/emr-user-role-mapper-s3storagebasedauthorizationmanager/pom.xml
@@ -49,6 +49,19 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazonaws.glue</groupId>
+            <artifactId>aws-glue-datacatalog-client-common</artifactId>
+            <version>1.10.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws.emr</groupId>
+            <artifactId>urm-credentials-provider</artifactId>
+            <version>1.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws.version}</version>

--- a/emr-user-role-mapper-s3storagebasedauthorizationmanager/src/main/java/com/amazonaws/emr/urm/glue/credentialsprovider/URMCredentialsProviderFactory.java
+++ b/emr-user-role-mapper-s3storagebasedauthorizationmanager/src/main/java/com/amazonaws/emr/urm/glue/credentialsprovider/URMCredentialsProviderFactory.java
@@ -1,0 +1,14 @@
+package com.amazonaws.emr.urm.glue.credentialsprovider;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.emr.urm.credentialsprovider.URMCredentialsProvider;
+import com.amazonaws.glue.catalog.metastore.AWSCredentialsProviderFactory;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+public class URMCredentialsProviderFactory implements AWSCredentialsProviderFactory {
+
+  @Override
+  public AWSCredentialsProvider buildAWSCredentialsProvider(HiveConf hiveConf) {
+    return new URMCredentialsProvider();
+  }
+}


### PR DESCRIPTION
*Issue #41,  (https://github.com/awslabs/amazon-emr-user-role-mapper/issues/41)

*Description of changes:*
This change introduce connector for AWS Glue Hive Meta store client.
Glue connector uses this configuration to inject AWS Credentials provide while
communicating with AWS Glue service from Hive Meta store
