### PR TITLE
Support trino with urm

### DIFF
--- a/emr-user-role-mapper-application/usr/install/ba-script.sh
+++ b/emr-user-role-mapper-application/usr/install/ba-script.sh
@@ -186,8 +186,8 @@ sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/user-role-mapper.properties /emr/user-r
 echo "Getting and setting mappings.json"
 sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/mappings.json /emr/user-role-mapper/conf/
 sudo sed -i "s#\$AWS_ROLE#${ROLE_ARN}#g" /emr/user-role-mapper/conf/mappings.json
-echo "Getting emr-user-role-mapper-application-1.1.0-jar-with-dependencies-and-exclude-classes.jar from S3"
-sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/emr-user-role-mapper-application-1.1.0-jar-with-dependencies-and-exclude-classes.jar /usr/share/aws/emr/user-role-mapper/lib/
+echo "Getting emr-user-role-mapper-application-1.2.0-SNAPSHOT-jar-with-dependencies-and-exclude-classes.jar from S3"
+sudo aws s3 cp s3://${BUCKET}/${S3_PATH}/emr-user-role-mapper-application-1.2.0-SNAPSHOT-jar-with-dependencies-and-exclude-classes.jar /usr/share/aws/emr/user-role-mapper/lib/
 
 echo "Setting permissions"
 sudo chown -R userrolemapper:$sudo_user /emr/user-role-mapper

--- a/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProvider.java
+++ b/emr-user-role-mapper-credentials-provider/src/main/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProvider.java
@@ -29,6 +29,7 @@ public class URMCredentialsProvider
     private final Set<String> usersAllowedToImpersonate;
 
     private final String createdBy;
+    private final String createdFor;
 
     final private URMCredentialsFetcher urmCredentialsFetcher;
 
@@ -40,6 +41,7 @@ public class URMCredentialsProvider
     {
         this(new URMCredentialsFetcher(getUgi().getShortUserName()),
                 DEFAULT_ALLOWED_USERS,
+                getUgi().getShortUserName(),
                 getRealUser()
                 );
     }
@@ -53,6 +55,7 @@ public class URMCredentialsProvider
     {
         this(new URMCredentialsFetcher(getUgi().getShortUserName()),
                 getUsersAllowedToImpersonate(configuration),
+                getUgi().getShortUserName(),
                 getRealUser());
     }
 
@@ -64,7 +67,7 @@ public class URMCredentialsProvider
      */
     @VisibleForTesting
     URMCredentialsProvider(URMCredentialsFetcher urmCredentialsFetcher, Set<String> usersAllowedToImpersonate,
-            String realUser)
+            String currentUser, String realUser)
     {
         Preconditions.checkNotNull(urmCredentialsFetcher);
         Preconditions.checkNotNull(usersAllowedToImpersonate);
@@ -72,6 +75,7 @@ public class URMCredentialsProvider
         LOG.debug("Building URMCredentials Provider.");
         this.urmCredentialsFetcher = urmCredentialsFetcher;
         this.usersAllowedToImpersonate = usersAllowedToImpersonate;
+        this.createdFor = currentUser;
         this.createdBy = realUser;
     }
 
@@ -93,7 +97,7 @@ public class URMCredentialsProvider
             return null;
         }
 
-        String callingUser = getUgi().getShortUserName();
+        String callingUser = this.createdFor;
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("I am impersonating user: " + callingUser);

--- a/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
+++ b/emr-user-role-mapper-credentials-provider/src/test/java/com/amazonaws/emr/urm/credentialsprovider/URMCredentialsProviderTest.java
@@ -37,7 +37,7 @@ public class URMCredentialsProviderTest
     {
         URMCredentialsFetcher mockURMCredentialsFetcher = mock(URMCredentialsFetcher.class);
         URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
-                new HashSet<>(Arrays.asList("user1", "user2")), REALUSER);
+                new HashSet<>(Arrays.asList("user1", "user2")), USER, REALUSER);
         assertNull(urmCredentialsProvider.getCredentials());
     }
 
@@ -64,7 +64,7 @@ public class URMCredentialsProviderTest
 
         Set<String> allowedList = new HashSet<>(Collections.singletonList(REALUSER));
         URMCredentialsProvider urmCredentialsProvider = new URMCredentialsProvider(mockURMCredentialsFetcher,
-                allowedList, REALUSER);
+                allowedList, USER, REALUSER);
 
         AWSCredentials returnedCreds = urmCredentialsProvider.getCredentials();
 


### PR DESCRIPTION
Support URM with trino:

In trino proxy user for UserGroupInformation(UGI) is set to end user(who submitted the query) when the FileSystem object is created which is when trino will create custom AWSCredentialsProvider. So in custom credential provider UserGroupInformation.getCurrentUser() should be called inside of the AWSCredentialsProvider constructor and use the same user in AWSCredentialsProvider.getCredentials() call.
