### PR TITLE
Build the application and interface by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,22 @@
     <modules>
         <module>emr-user-role-mapper-interface</module>
         <module>emr-user-role-mapper-application</module>
-        <module>emr-user-role-mapper-credentials-provider</module>
-        <module>emr-user-role-mapper-s3storagebasedauthorizationmanager</module>
     </modules>
-
+    
+   <profiles>
+   	<profile>
+      		<id>impersonation-credentials-provider</id>
+      		<modules>
+        		<module>emr-user-role-mapper-credentials-provider</module>
+      		</modules>
+    	</profile>
+   	<profile>
+      		<id>hive-metastore-connector</id>
+      		<modules>
+        		<module>emr-user-role-mapper-s3storagebasedauthorizationmanager</module>
+      		</modules>
+    	</profile>
+   </profiles>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
The client connectors should not be built by default specially with all the dependencies that they bring along.
To enable the client connectors provide way in maven.

https://github.com/awslabs/amazon-emr-user-role-mapper/issues/53

*Issue #, if available:*

*Description of changes:*

Structured the pom to not build all modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
