### PR TITLE
In scenarios where the id command takes > 3 seconds we should not cac…

### DIFF
--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/Constants.java
@@ -89,6 +89,9 @@ final public class Constants {
     // Default value is true.
     public static final String REGIONAL_STS_ENDPOINT_ENABLED = "rolemapper.regional.sts.endpoint.enabled";
 
+    // How long to wait for the system commands to return a response before throwing a timeout exception
+    public static final String COMMAND_TIMEOUT_SECONDS = "command.timeout.seconds";
+    public static final String DEFAULT_COMMAND_TIMEOUT_SECONDS = "3";
     private Constants() {
     }
 

--- a/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/system/factory/PrincipalResolverFactory.java
+++ b/emr-user-role-mapper-application/src/main/java/com/amazon/aws/emr/common/system/factory/PrincipalResolverFactory.java
@@ -30,7 +30,7 @@ public class PrincipalResolverFactory implements Factory<PrincipalResolver> {
 
         log.info("Using principal resolver strategy: {}", principalResolverStrategy);
         if (Constants.DEFAULT_PRINCIPAL_RESOLVER_STRATEGY.equalsIgnoreCase(principalResolverStrategy))
-            return new CommandBasedPrincipalResolver();
+            return new CommandBasedPrincipalResolver(appConfig);
 
         return new JniBasedPrincipalResolver();
     }

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/common/system/impl/PrincipalResolverTestBase.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/common/system/impl/PrincipalResolverTestBase.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class PrincipalResolverTestBase {
+public abstract class PrincipalResolverTestBase {
     protected static final Integer TTL_SECS = 3;
 
     protected static final int VALID_UID = 123;

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/common/system/user/TestCommandBasedPrincipalResolver.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/common/system/user/TestCommandBasedPrincipalResolver.java
@@ -3,6 +3,7 @@
 
 package com.amazon.aws.emr.common.system.user;
 
+import com.amazon.aws.emr.ApplicationConfiguration;
 import com.amazon.aws.emr.common.system.PrincipalResolver;
 import com.amazon.aws.emr.common.system.impl.CommandBasedPrincipalResolver;
 
@@ -12,6 +13,12 @@ import java.nio.file.Paths;
 
 public class TestCommandBasedPrincipalResolver extends CommandBasedPrincipalResolver implements PrincipalResolver {
     private static final String TEST_USERS_FILE = "/test-users";
+
+    public TestCommandBasedPrincipalResolver()
+    {
+        // TODO: would be better if the same config could be injected that is used in MetadataControllerTest
+        super(new ApplicationConfiguration());
+    }
 
     protected Path getSystemUsersFileName() {
         java.net.URL url = this.getClass().getResource(TEST_USERS_FILE);

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/IntegrationTestsUserService.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/IntegrationTestsUserService.java
@@ -1,5 +1,6 @@
 package com.amazon.aws.emr.integration;
 
+import com.amazon.aws.emr.ApplicationConfiguration;
 import com.amazon.aws.emr.common.system.impl.CommandBasedPrincipalResolver;
 import com.amazon.aws.emr.common.system.user.UserIdService;
 import java.util.Arrays;
@@ -13,7 +14,7 @@ public class IntegrationTestsUserService implements UserIdService {
   @Override
   public OptionalInt resolveSystemUID(String localAddr, int localPort, String remoteAddr,
       int remotePort, boolean isNativeIMDSApi) {
-     Optional<String> uid = new CommandBasedPrincipalResolver()
+     Optional<String> uid = new CommandBasedPrincipalResolver(new ApplicationConfiguration())
         .runCommand(Arrays.asList("id", "-u")).stream().findFirst();
      return uid.map(u -> OptionalInt.of(Integer.parseInt(u)))
          .orElse(OptionalInt.empty());

--- a/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/policyunionmapper/PoliciesUnionMappingProviderImplIntegrationTest.java
+++ b/emr-user-role-mapper-application/src/test/com/amazon/aws/emr/integration/policyunionmapper/PoliciesUnionMappingProviderImplIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import com.amazon.aws.emr.ApplicationConfiguration;
 import com.amazon.aws.emr.common.system.impl.CommandBasedPrincipalResolver;
 import com.amazon.aws.emr.integration.IntegrationTestBase;
 import com.amazon.aws.emr.integration.utils.IAMUtils;
@@ -63,7 +64,7 @@ public class PoliciesUnionMappingProviderImplIntegrationTest extends Integration
   private static List<String> groups;
 
   static private void createAwsResources() {
-    groups = new CommandBasedPrincipalResolver().runCommand(Arrays.asList("id", "-Gn"));
+    groups = new CommandBasedPrincipalResolver(new ApplicationConfiguration()).runCommand(Arrays.asList("id", "-Gn"));
     if (groups.isEmpty()) {
       log.warn("No groups found - skipping the tests");
       return;


### PR DESCRIPTION
…he the null/empty result.

This commit ensures backwards compatibility by only throwing unchecked exception when system
commands take longer than allowed time but by actually surfacing the exception at cache loader
level we are ensuring that a single timeout does not result in the bad result being cached for
cache timeout period which results in repeated access failures for a user.

We are also making the command timeout a system property instead of hardcoded 3 seconds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
