### PR TITLE
Fix location for authorization when table location is not specified

### DIFF
--- a/emr-user-role-mapper-s3storagebasedauthorizationmanager/src/main/java/com/amazonaws/emr/urm/hive/urmstoragebasedauthorizer/S3StorageBasedAuthorizationProvider.java
+++ b/emr-user-role-mapper-s3storagebasedauthorizationmanager/src/main/java/com/amazonaws/emr/urm/hive/urmstoragebasedauthorizer/S3StorageBasedAuthorizationProvider.java
@@ -113,7 +113,28 @@ public class S3StorageBasedAuthorizationProvider extends HiveAuthorizationProvid
         if(table.isView() || table.isMaterializedView()){
             return;
         }
-        authorize(table.getDataLocation().toString(), readRequiredPriv, writeRequiredPriv);
+
+        org.apache.hadoop.fs.Path tableLocation = table.getDataLocation();
+        String tableLocationStr = null;
+
+        if (tableLocation == null){
+            LOG.info("Table Location not specified. Building it.");
+            String databaseName = table.getDbName();
+            LOG.info("Database: " + databaseName);
+            String catalogName = table.getCatName();
+            LOG.info("Catalog: " + catalogName);
+            Database db = hive_db.getDatabase(catalogName,databaseName);
+            String dbLocation = db.getLocationUri();
+            LOG.info("DB Location: " + dbLocation);
+            tableLocationStr = dbLocation + "/" + table.getTableName();
+        }
+        else{
+            tableLocationStr = tableLocation.toString();
+        }
+
+        LOG.info("Table Location:" + tableLocationStr);
+
+        authorize(tableLocationStr, readRequiredPriv, writeRequiredPriv);
     }
 
     @Override


### PR DESCRIPTION
Fixed issues:
- #60 

Description of changes:

With this fix we allow to govern table creation statements which do not include a LOCATION. In specific the location is retrieved from the database and used to build the table location to be checked for authorization.

If the database location is **s3://YOURBUCKET/YOURFOLDER/mydb/** 

```
CREATE DATABASE mydb LOCATION "s3://YOURBUCKET/YOURFOLDER/mydb/";
```

and I try to create a table as follow:

```
CREATE TABLE parquet_db_1.test1 (
a int,
b int)
STORED AS PARQUET;
```

the table location is automatically setup as **s3://YOURBUCKET/YOURFOLDER/mydb/test1/** and this location is evaluated for authorization purposes.

As a result the below statements work.

```
CREATE DATABASE mydb LOCATION "s3://YOURBUCKET/YOURFOLDER/mydb/";
 
CREATE TABLE mydb.test1 (
a int,
b int)
STORED AS PARQUET;

CREATE TABLE mydb.test2 (
a int,
b int)
STORED AS PARQUET
LOCATION "s3://YOURBUCKET/YOURFOLDER/mydb/test2/";

USE mydb;
 
CREATE TABLE test3 (
a int,
b int)
```

If we do not specify a location, on the logs we'll see something like this:

```
2023-06-28T09:57:48,766 INFO  [pool-6-thread-6([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(121)) - Table Location not specified. Building it.
2023-06-28T09:57:48,766 INFO  [pool-6-thread-6([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(123)) - Database: mydb
2023-06-28T09:57:48,766 INFO  [pool-6-thread-6([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(125)) - Catalog: hive
2023-06-28T09:57:48,773 INFO  [pool-6-thread-6([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(128)) - DB Location:s3://YOURBUCKET/YOURFOLDER/mydb
2023-06-28T09:57:48,773 INFO  [pool-6-thread-6([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(135)) - Table Location:s3://YOURBUCKET/YOURFOLDER/mydb/test3
```

If we do specify a location, on the logs we'll see something like this:

```
2023-06-28T10:21:10,669 INFO  [pool-6-thread-9([])]: urmstoragebasedauthorizer.S3StorageBasedAuthorizationProvider (S3StorageBasedAuthorizationProvider.java:authorize(135)) - Table Location:s3://YOURBUCKET/YOURFOLDER/mydb/test2
```