### PR TITLE
Recursively decode a URL in the filter to sanitize the URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ To get more information, including installation instructions, see URM Credential
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Limitations
+
+URM does not work with tcp6 and IMDSv6 currently. Please do not use URM on installations that use tcp6 traffic along with IMDSv6.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.


### PR DESCRIPTION
This will prevent an attacker to grab IMDS credentials using a URL encoded request.

*Issue #, if available:*
https://github.com/awslabs/amazon-emr-user-role-mapper/issues/62

*Testing

Ran and built all the integ tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
